### PR TITLE
Modify (slightly) the 2020 drivetrain controller to model 2022's drivetrain

### DIFF
--- a/src/main/cpp/CANSparkMaxUtil.cpp
+++ b/src/main/cpp/CANSparkMaxUtil.cpp
@@ -1,0 +1,31 @@
+// Copyright (c) FRC Team 3512. All Rights Reserved.
+
+#include "CANSparkMaxUtil.hpp"
+
+namespace frc3512 {
+
+void SetCANSparkMaxBusUsage(rev::CANSparkMax& motor, Usage usage) {
+    if (usage == Usage::kAll) {
+        motor.SetPeriodicFramePeriod(rev::CANSparkMax::PeriodicFrame::kStatus1,
+                                     20);
+        motor.SetPeriodicFramePeriod(rev::CANSparkMax::PeriodicFrame::kStatus2,
+                                     20);
+    } else if (usage == Usage::kPositionOnly) {
+        motor.SetPeriodicFramePeriod(rev::CANSparkMax::PeriodicFrame::kStatus1,
+                                     500);
+        motor.SetPeriodicFramePeriod(rev::CANSparkMax::PeriodicFrame::kStatus2,
+                                     20);
+    } else if (usage == Usage::kVelocityOnly) {
+        motor.SetPeriodicFramePeriod(rev::CANSparkMax::PeriodicFrame::kStatus1,
+                                     20);
+        motor.SetPeriodicFramePeriod(rev::CANSparkMax::PeriodicFrame::kStatus2,
+                                     500);
+    } else if (usage == Usage::kMinimal) {
+        motor.SetPeriodicFramePeriod(rev::CANSparkMax::PeriodicFrame::kStatus1,
+                                     500);
+        motor.SetPeriodicFramePeriod(rev::CANSparkMax::PeriodicFrame::kStatus2,
+                                     500);
+    }
+}
+
+}  // namespace frc3512

--- a/src/main/cpp/Robot.cpp
+++ b/src/main/cpp/Robot.cpp
@@ -70,15 +70,15 @@ void Robot::ExpectAutonomousEndConds() {
         EXPECT_FALSE(m_autonChooser.IsSuspended())
             << "Autonomous mode didn't finish within the autonomous period";
 
-        // EXPECT_TRUE(drivetrain.AtGoal());
+        EXPECT_TRUE(drivetrain.AtGoal());
 
         // Verify left/right wheel velocities are close to zero
-        /* EXPECT_NEAR(
+        EXPECT_NEAR(
             drivetrain.GetStates()(DrivetrainController::State::kLeftVelocity),
-            0.0, 0.01); */
-        /* EXPECT_NEAR(
+            0.0, 0.01);
+        EXPECT_NEAR(
             drivetrain.GetStates()(DrivetrainController::State::kRightVelocity),
-            0.0, 0.01); */
+            0.0, 0.01);
     }
 }
 

--- a/src/main/cpp/controllers/DrivetrainController.cpp
+++ b/src/main/cpp/controllers/DrivetrainController.cpp
@@ -1,0 +1,278 @@
+// Copyright (c) FRC Team 3512. All Rights Reserved.
+
+#include "controllers/DrivetrainController.hpp"
+
+#include <algorithm>
+#include <cmath>
+
+#include <frc/MathUtil.h>
+#include <frc/controller/LinearQuadraticRegulator.h>
+#include <frc/fmt/Eigen.h>
+#include <frc/kinematics/DifferentialDriveKinematics.h>
+#include <frc/system/plant/DCMotor.h>
+#include <frc/system/plant/LinearSystemId.h>
+#include <frc/trajectory/TrajectoryGenerator.h>
+#include <frc/trajectory/constraint/CentripetalAccelerationConstraint.h>
+#include <frc/trajectory/constraint/DifferentialDriveVelocitySystemConstraint.h>
+
+using namespace frc3512;
+
+const frc::LinearSystem<2, 2, 2> DrivetrainController::kPlant{GetPlant()};
+
+DrivetrainController::DrivetrainController() {
+    m_A = JacobianX(Eigen::Vector<double, 7>::Zero());
+    m_B = JacobianU(Eigen::Vector<double, 2>::Zero());
+
+    Eigen::Vector<double, 7> x = Eigen::Vector<double, 7>::Zero();
+    for (auto velocity = -kMaxV; velocity < kMaxV; velocity += 0.01_mps) {
+        x(State::kLeftVelocity) = velocity.value();
+        x(State::kRightVelocity) = velocity.value();
+        m_table.Insert(velocity, ControllerGainForState(x));
+    }
+
+    m_trajectoryTimeElapsed.Start();
+}
+
+void DrivetrainController::AddTrajectory(
+    const frc::Pose2d& start, const std::vector<frc::Translation2d>& interior,
+    const frc::Pose2d& end, const frc::TrajectoryConfig& config) {
+    bool hadTrajectory = HaveTrajectory();
+
+    m_trajectory = m_trajectory + frc::TrajectoryGenerator::GenerateTrajectory(
+                                      start, interior, end, config);
+    m_goal = m_trajectory.States().back().pose;
+
+    // If a trajectory wasn't being tracked until now, reset the timer.
+    // Otherwise, let the timer continue on the current trajectory.
+    if (!hadTrajectory) {
+        m_trajectoryTimeElapsed.Reset();
+    }
+}
+
+void DrivetrainController::AddTrajectory(
+    const std::vector<frc::Pose2d>& waypoints,
+    const frc::TrajectoryConfig& config) {
+    bool hadTrajectory = HaveTrajectory();
+
+    m_trajectory = m_trajectory + frc::TrajectoryGenerator::GenerateTrajectory(
+                                      waypoints, config);
+    m_goal = m_trajectory.States().back().pose;
+
+    // If a trajectory wasn't being tracked until now, reset the timer.
+    // Otherwise, let the timer continue on the current trajectory.
+    if (!hadTrajectory) {
+        m_trajectoryTimeElapsed.Reset();
+    }
+}
+
+bool DrivetrainController::HaveTrajectory() const {
+    return m_trajectory.States().size() > 0;
+}
+
+void DrivetrainController::AbortTrajectories() {
+    m_trajectory = frc::Trajectory{};
+}
+
+bool DrivetrainController::AtGoal() const {
+    frc::Pose2d ref{units::meter_t{m_r(State::kX)},
+                    units::meter_t{m_r(State::kY)},
+                    units::radian_t{m_r(State::kHeading)}};
+
+    // Checking the time ensures a trajectory with the same start and end pose
+    // will get tracked before AtGoal() returns true
+    return m_goal == ref &&
+           m_trajectoryTimeElapsed.Get() >= m_trajectory.TotalTime() &&
+           m_atReferences;
+}
+
+void DrivetrainController::Reset(const frc::Pose2d& initialPose) {
+    Eigen::Vector<double, 7> xHat;
+    xHat(0) = initialPose.X().value();
+    xHat(1) = initialPose.Y().value();
+    xHat(2) = initialPose.Rotation().Radians().value();
+    xHat.block<4, 1>(3, 0).setZero();
+
+    m_ff.Reset(xHat);
+    m_r = xHat;
+    m_nextR = xHat;
+    m_goal = initialPose;
+
+    UpdateAtReferences(Eigen::Vector<double, 5>::Zero());
+}
+
+Eigen::Vector<double, 2> DrivetrainController::Calculate(
+    const Eigen::Vector<double, 7>& x) {
+    m_u = Eigen::Vector<double, 2>::Zero();
+
+    if (HaveTrajectory()) {
+        frc::Trajectory::State ref =
+            m_trajectory.Sample(m_trajectoryTimeElapsed.Get());
+        auto [vlRef, vrRef] =
+            ToWheelVelocities(ref.velocity, ref.curvature, kWidth);
+
+        m_nextR =
+            Eigen::Vector<double, 7>{ref.pose.X().value(),
+                                     ref.pose.Y().value(),
+                                     ref.pose.Rotation().Radians().value(),
+                                     vlRef.value(),
+                                     vrRef.value(),
+                                     0.0,
+                                     0.0};
+
+        Eigen::Vector<double, 2> u_fb = Controller(x, m_r);
+        u_fb = frc::DesaturateInputVector<2>(u_fb, 12.0);
+        m_u = u_fb + m_ff.Calculate(m_nextR);
+        m_u = frc::DesaturateInputVector<2>(m_u, 12.0);
+
+        Eigen::Vector<double, 5> error =
+            m_nextR.block<5, 1>(0, 0) - x.block<5, 1>(0, 0);
+        error(State::kHeading) =
+            frc::AngleModulus(units::radian_t{error(State::kHeading)}).value();
+        UpdateAtReferences(error);
+
+        m_r = m_nextR;
+    }
+
+    if (AtGoal() && HaveTrajectory()) {
+        m_trajectory = frc::Trajectory{};
+        m_trajectoryTimeElapsed.Reset();
+    }
+
+    return m_u;
+}
+
+frc::LinearSystem<2, 2, 2> DrivetrainController::GetPlant() {
+    return frc::LinearSystemId::IdentifyDrivetrainSystem(kLinearV, kLinearA,
+                                                         kAngularV, kAngularA);
+}
+
+frc::TrajectoryConfig DrivetrainController::MakeTrajectoryConfig() {
+    return MakeTrajectoryConfig(0_mps, 0_mps);
+}
+
+frc::TrajectoryConfig DrivetrainController::MakeTrajectoryConfig(
+    units::meters_per_second_t startVelocity,
+    units::meters_per_second_t endVelocity) {
+    frc::TrajectoryConfig config{kMaxV, 2.2_mps_sq};
+
+    config.AddConstraint(frc::DifferentialDriveVelocitySystemConstraint{
+        kPlant, frc::DifferentialDriveKinematics{kWidth}, 8_V});
+
+    // Slows drivetrain down on curves to avoid understeer that introduces
+    // odometry errors
+    config.AddConstraint(frc::CentripetalAccelerationConstraint{3_mps_sq});
+
+    config.SetStartVelocity(startVelocity);
+    config.SetEndVelocity(endVelocity);
+
+    return config;
+}
+
+Eigen::Matrix<double, 2, 5> DrivetrainController::ControllerGainForState(
+    const Eigen::Vector<double, 7>& x) {
+    // The DARE is ill-conditioned if the velocity is close to zero, so don't
+    // let the system stop.
+    double velocity =
+        (x(State::kLeftVelocity) + x(State::kRightVelocity)) / 2.0;
+    if (std::abs(velocity) < 1e-4) {
+        return Eigen::Matrix<double, 2, 5>::Zero();
+    }
+
+    m_A(State::kY, State::kHeading) = velocity;
+    return frc::LinearQuadraticRegulator<5, 2>(m_A, m_B, m_Q, m_R,
+                                               Constants::kControllerPeriod)
+        .K();
+}
+
+Eigen::Vector<double, 2> DrivetrainController::Controller(
+    const Eigen::Vector<double, 7>& x, const Eigen::Vector<double, 7>& r) {
+    // This implements the linear time-varying differential drive controller in
+    // theorem 9.6.3 of https://tavsys.net/controls-in-frc.
+    units::meters_per_second_t velocity{
+        (x(State::kLeftVelocity) + x(State::kRightVelocity)) / 2.0};
+    const auto& K = m_table[velocity];
+
+    Eigen::Matrix<double, 5, 5> inRobotFrame =
+        Eigen::Matrix<double, 5, 5>::Identity();
+    inRobotFrame(0, 0) = std::cos(x(State::kHeading));
+    inRobotFrame(0, 1) = std::sin(x(State::kHeading));
+    inRobotFrame(1, 0) = -std::sin(x(State::kHeading));
+    inRobotFrame(1, 1) = std::cos(x(State::kHeading));
+
+    Eigen::Vector<double, 5> error = r.block<5, 1>(0, 0) - x.block<5, 1>(0, 0);
+    error(State::kHeading) =
+        frc::AngleModulus(units::radian_t{error(State::kHeading)}).value();
+    return K * inRobotFrame * error;
+}
+
+Eigen::Vector<double, 7> DrivetrainController::Dynamics(
+    const Eigen::Vector<double, 7>& x, const Eigen::Vector<double, 2>& u) {
+    Eigen::Matrix<double, 4, 2> B;
+    B.block<2, 2>(0, 0) = kPlant.B();
+    B.block<2, 2>(2, 0).setZero();
+    Eigen::Matrix<double, 4, 4> A;
+    A.block<2, 2>(0, 0) = kPlant.A();
+    A.block<2, 2>(2, 0).setIdentity();
+    A.block<4, 2>(0, 2).setZero();
+
+    double v = (x(State::kLeftVelocity) + x(State::kRightVelocity)) / 2.0;
+
+    Eigen::Vector<double, 7> xdot;
+    xdot(0) = v * std::cos(x(State::kHeading));
+    xdot(1) = v * std::sin(x(State::kHeading));
+    xdot(2) =
+        ((x(State::kRightVelocity) - x(State::kLeftVelocity)) / kWidth).value();
+    xdot.block<4, 1>(3, 0) = A * x.block<4, 1>(3, 0) + B * u;
+    return xdot;
+}
+
+Eigen::Matrix<double, 5, 5> DrivetrainController::JacobianX(
+    const Eigen::Vector<double, 7>& x) {
+    return Eigen::Matrix<double, 5, 5>{
+        {0.0, 0.0, 0.0, 0.5, 0.5},
+        {0.0, 0.0, (x(State::kLeftVelocity) + x(State::kRightVelocity)) / 2.0,
+         0.0, 0.0},
+        {0.0, 0.0, 0.0, -1.0 / kWidth.value(), 1.0 / kWidth.value()},
+        {0.0, 0.0, 0.0, kPlant.A(0, 0), kPlant.A(0, 1)},
+        {0.0, 0.0, 0.0, kPlant.A(1, 0), kPlant.A(1, 1)}};
+}
+
+Eigen::Matrix<double, 5, 2> DrivetrainController::JacobianU(
+    const Eigen::Vector<double, 2>& u) {
+    return Eigen::Matrix<double, 5, 2>{{0.0, 0.0},
+                                       {0.0, 0.0},
+                                       {0.0, 0.0},
+                                       {kPlant.B(0, 0), kPlant.B(0, 1)},
+                                       {kPlant.B(1, 0), kPlant.B(1, 1)}};
+}
+
+Eigen::Vector<double, 5> DrivetrainController::LocalMeasurementModel(
+    const Eigen::Vector<double, 7>& x, const Eigen::Vector<double, 2>& u) {
+    auto plant = frc::LinearSystemId::IdentifyDrivetrainSystem(
+        kLinearV, kLinearA, kAngularV, kAngularA);
+    Eigen::Vector<double, 2> xdot =
+        plant.A() * x.block<2, 1>(State::kLeftVelocity, 0) + plant.B() * u;
+
+    return Eigen::Vector<double, 5>{
+        x(State::kHeading), x(State::kLeftPosition), x(State::kRightPosition),
+        (xdot(0) + xdot(1)) / 2.0,
+        (x(State::kRightVelocity) * x(State::kRightVelocity) -
+         x(State::kLeftVelocity) * x(State::kLeftVelocity)) /
+            (2.0 * kWidth.value())};
+}
+
+Eigen::Vector<double, 2> DrivetrainController::GlobalMeasurementModel(
+    const Eigen::Vector<double, 7>& x, const Eigen::Vector<double, 2>& u) {
+    static_cast<void>(u);
+
+    return Eigen::Vector<double, 2>{x(State::kX), x(State::kY)};
+}
+
+void DrivetrainController::UpdateAtReferences(
+    const Eigen::Vector<double, 5>& error) {
+    m_atReferences = std::abs(error(0)) < kPositionTolerance &&
+                     std::abs(error(1)) < kPositionTolerance &&
+                     std::abs(error(2)) < kAngleTolerance &&
+                     std::abs(error(3)) < kVelocityTolerance &&
+                     std::abs(error(4)) < kVelocityTolerance;
+}

--- a/src/main/cpp/subsystems/Drivetrain.cpp
+++ b/src/main/cpp/subsystems/Drivetrain.cpp
@@ -1,0 +1,412 @@
+// Copyright (c) FRC Team 3512. All Rights Reserved.
+
+#include "subsystems/Drivetrain.hpp"
+
+#include <algorithm>
+
+#include <frc/DriverStation.h>
+#include <frc/Joystick.h>
+#include <frc/MathUtil.h>
+#include <frc/RobotBase.h>
+#include <frc/RobotController.h>
+#include <frc/StateSpaceUtil.h>
+#include <frc/drive/DifferentialDrive.h>
+#include <frc/fmt/Eigen.h>
+#include <frc/smartdashboard/SmartDashboard.h>
+
+#include "CANSparkMaxUtil.hpp"
+
+using namespace frc3512;
+
+const Eigen::Matrix<double, 2, 2> Drivetrain::kGlobalR =
+    frc::MakeCovMatrix(0.2, 0.2);
+
+const frc::LinearSystem<2, 2, 2> Drivetrain::kPlant{
+    DrivetrainController::GetPlant()};
+
+Drivetrain::Drivetrain()
+    : ControlledSubsystemBase(
+          "Drivetrain",
+          {ControllerLabel{"X", "m"}, ControllerLabel{"Y", "m"},
+           ControllerLabel{"Heading", "rad"},
+           ControllerLabel{"Left velocity", "m/s"},
+           ControllerLabel{"Right velocity", "m/s"},
+           ControllerLabel{"Left position", "m"},
+           ControllerLabel{"Right position", "m"}},
+          {ControllerLabel{"Left voltage", "V"},
+           ControllerLabel{"Right voltage", "V"}},
+          {ControllerLabel{"Heading", "rad"},
+           ControllerLabel{"Left position", "m"},
+           ControllerLabel{"Right position", "m"},
+           ControllerLabel{"Longitudinal Acceleration", "m/s^2"},
+           ControllerLabel{"Lateral Acceleration", "m/s^2"}}) {
+    SetCANSparkMaxBusUsage(m_leftLeader, Usage::kMinimal);
+    SetCANSparkMaxBusUsage(m_leftFollower, Usage::kMinimal);
+    SetCANSparkMaxBusUsage(m_rightLeader, Usage::kMinimal);
+    SetCANSparkMaxBusUsage(m_rightFollower, Usage::kMinimal);
+
+    m_leftLeader.SetSmartCurrentLimit(60);
+    m_leftFollower.SetSmartCurrentLimit(60);
+    m_rightLeader.SetSmartCurrentLimit(60);
+    m_rightFollower.SetSmartCurrentLimit(60);
+
+    // Ensures CANSparkMax::Get() returns an initialized value
+    m_leftGrbx.Set(0.0);
+    m_rightGrbx.Set(0.0);
+
+    m_leftGrbx.SetInverted(true);
+
+    m_leftEncoder.SetSamplesToAverage(10);
+    m_rightEncoder.SetSamplesToAverage(10);
+
+    m_leftEncoder.SetReverseDirection(false);
+    m_rightEncoder.SetReverseDirection(true);
+    m_leftEncoder.SetDistancePerPulse(DrivetrainController::kDpP);
+    m_rightEncoder.SetDistancePerPulse(DrivetrainController::kDpP);
+
+    // Reset the pose estimate to the field's bottom-left corner with the turret
+    // facing in the target's general direction. This is relatively close to the
+    // robot's testing configuration, so the turret won't hit the soft limits.
+    Reset(frc::Pose2d{0_m, 0_m, units::radian_t{wpi::numbers::pi}});
+
+    frc::SmartDashboard::PutData(&m_field);
+}
+
+frc::Pose2d Drivetrain::GetReferencePose() const {
+    const auto& x = m_controller.GetReferences();
+    return frc::Pose2d{
+        units::meter_t{x(DrivetrainController::State::kX)},
+        units::meter_t{x(DrivetrainController::State::kY)},
+        units::radian_t{x(DrivetrainController::State::kHeading)}};
+}
+
+frc::Pose2d Drivetrain::GetPose() const {
+    const auto& x = m_observer.Xhat();
+    return frc::Pose2d{
+        units::meter_t{x(DrivetrainController::State::kX)},
+        units::meter_t{x(DrivetrainController::State::kY)},
+        units::radian_t{x(DrivetrainController::State::kHeading)}};
+}
+
+units::meter_t Drivetrain::GetLeftUltrasonicDistance() const {
+    return m_leftUltrasonicDistance;
+}
+
+units::meter_t Drivetrain::GetRightUltrasonicDistance() const {
+    return m_rightUltrasonicDistance;
+}
+
+units::radian_t Drivetrain::GetAngle() const {
+    return units::degree_t{m_imu.GetAngle()} + m_headingOffset;
+}
+
+units::meter_t Drivetrain::GetLeftPosition() const {
+    return units::meter_t{m_leftEncoder.GetDistance()};
+}
+
+units::meter_t Drivetrain::GetRightPosition() const {
+    return units::meter_t{m_rightEncoder.GetDistance()};
+}
+
+units::meters_per_second_t Drivetrain::GetLeftVelocity() const {
+    return units::meters_per_second_t{m_leftEncoder.GetRate()};
+}
+
+units::meters_per_second_t Drivetrain::GetRightVelocity() const {
+    return units::meters_per_second_t{m_rightEncoder.GetRate()};
+}
+
+units::meters_per_second_squared_t Drivetrain::GetAccelerationX() const {
+    return -m_imu.GetAccelX();
+}
+
+units::meters_per_second_squared_t Drivetrain::GetAccelerationY() const {
+    return -m_imu.GetAccelY();
+}
+
+void Drivetrain::Reset(const frc::Pose2d& initialPose) {
+    using State = frc::sim::DifferentialDrivetrainSim::State;
+
+    m_observer.Reset();
+    m_controller.Reset(initialPose);
+    m_u = Eigen::Vector<double, 2>::Zero();
+    m_leftEncoder.Reset();
+    m_rightEncoder.Reset();
+    m_imu.Reset();
+    m_headingOffset = initialPose.Rotation().Radians();
+
+    Eigen::Vector<double, 7> xHat;
+    xHat(State::kX) = initialPose.X().value();
+    xHat(State::kY) = initialPose.Y().value();
+    xHat(State::kHeading) = initialPose.Rotation().Radians().value();
+    xHat.block<4, 1>(3, 0).setZero();
+    m_observer.SetXhat(xHat);
+
+    if constexpr (frc::RobotBase::IsSimulation()) {
+        m_drivetrainSim.SetState(xHat);
+        m_field.SetRobotPose(initialPose);
+    }
+}
+
+void Drivetrain::CorrectWithGlobalOutputs(units::meter_t x, units::meter_t y,
+                                          units::second_t timestamp) {
+    Eigen::Vector<double, 2> globalY{x.value(), y.value()};
+    m_latencyComp.ApplyPastGlobalMeasurement<2>(
+        &m_observer, Constants::kControllerPeriod, globalY,
+        [&](const Eigen::Vector<double, 2>& u,
+            const Eigen::Vector<double, 2>& y) {
+            m_observer.Correct<2>(
+                u, y, &DrivetrainController::GlobalMeasurementModel, kGlobalR);
+        },
+        timestamp);
+}
+
+void Drivetrain::ControllerPeriodic() {
+    using Input = DrivetrainController::Input;
+
+    UpdateDt();
+
+    m_observer.Predict(m_u, GetDt());
+
+    Eigen::Vector<double, 5> y{
+        frc::AngleModulus(GetAngle()).value(), GetLeftPosition().value(),
+        GetRightPosition().value(), GetAccelerationX().value(),
+        GetAccelerationY().value()};
+    m_latencyComp.AddObserverState(m_observer, m_controller.GetInputs(), y,
+                                   frc::Timer::GetFPGATimestamp());
+    m_observer.Correct(m_controller.GetInputs(), y);
+
+    if (m_controller.HaveTrajectory()) {
+        m_u = m_controller.Calculate(m_observer.Xhat());
+
+        if (!AtGoal()) {
+            m_leftGrbx.SetVoltage(units::volt_t{m_u(Input::kLeftVoltage)});
+            m_rightGrbx.SetVoltage(units::volt_t{m_u(Input::kRightVoltage)});
+        } else {
+            m_leftGrbx.SetVoltage(0_V);
+            m_rightGrbx.SetVoltage(0_V);
+        }
+    } else {
+        // Update previous u stored in the controller. We don't care what the
+        // return value is.
+        static_cast<void>(m_controller.Calculate(m_observer.Xhat()));
+
+        // Run observer predict with inputs from teleop
+        m_u = Eigen::Vector<double, 2>{
+            std::clamp(m_leftGrbx.Get(), -1.0, 1.0) *
+                frc::RobotController::GetInputVoltage(),
+            std::clamp(m_rightGrbx.Get(), -1.0, 1.0) *
+                frc::RobotController::GetInputVoltage()};
+    }
+
+    Log(m_controller.GetReferences(), m_observer.Xhat(), m_u, y);
+
+    if constexpr (frc::RobotBase::IsSimulation()) {
+        auto batteryVoltage = frc::RobotController::GetInputVoltage();
+        m_drivetrainSim.SetInputs(
+            units::volt_t{std::clamp(m_leftGrbx.Get(), -1.0, 1.0) *
+                          batteryVoltage},
+            units::volt_t{std::clamp(m_rightGrbx.Get(), -1.0, 1.0) *
+                          batteryVoltage});
+
+        m_drivetrainSim.Update(GetDt());
+
+        m_leftEncoderSim.SetDistance(m_drivetrainSim.GetLeftPosition().value());
+        m_rightEncoderSim.SetDistance(
+            m_drivetrainSim.GetRightPosition().value());
+        m_imuSim.SetGyroAngleZ(units::degree_t{
+            m_drivetrainSim.GetHeading().Radians() - m_headingOffset});
+
+        const auto& plant = DrivetrainController::GetPlant();
+        Eigen::Vector<double, 2> x{m_drivetrainSim.GetLeftVelocity().value(),
+                                   m_drivetrainSim.GetRightVelocity().value()};
+        Eigen::Vector<double, 2> u{
+            std::clamp(m_leftGrbx.Get(), -1.0, 1.0) * batteryVoltage,
+            std::clamp(m_rightGrbx.Get(), -1.0, 1.0) * batteryVoltage};
+        Eigen::Vector<double, 2> xdot = plant.A() * x + plant.B() * u;
+        m_imuSim.SetAccelX(
+            -units::meters_per_second_squared_t{(xdot(0) + xdot(1)) / 2.0});
+
+        units::meters_per_second_t leftVelocity{x(0)};
+        units::meters_per_second_t rightVelocity{x(1)};
+        m_imuSim.SetAccelY(
+            -((rightVelocity * rightVelocity) - (leftVelocity * leftVelocity)) /
+            (2.0 * DrivetrainController::kWidth));
+
+        m_field.SetRobotPose(m_drivetrainSim.GetPose());
+    }
+}
+
+void Drivetrain::RobotPeriodic() {
+    m_leftUltrasonicDistance = m_leftDistanceFilter.Calculate(
+        units::volt_t{m_leftUltrasonic.GetVoltage()} * 1_m / 1_V);
+    m_rightUltrasonicDistance = m_rightDistanceFilter.Calculate(
+        units::volt_t{m_rightUltrasonic.GetVoltage()} * 1_m / 1_V);
+
+    if (frc::DriverStation::IsDisabled() ||
+        !frc::DriverStation::IsFMSAttached()) {
+        m_leftUltrasonicOutputEntry.SetDouble(m_leftUltrasonicDistance.value());
+        m_rightUltrasonicOutputEntry.SetDouble(
+            m_rightUltrasonicDistance.value());
+    }
+
+    if constexpr (frc::RobotBase::IsSimulation()) {
+        m_leftUltrasonicDistance = m_leftDistanceFilter.Calculate(
+            units::volt_t{m_leftUltrasonicSim.GetVoltage()} * 1_m / 1_V);
+        m_rightUltrasonicDistance = m_rightDistanceFilter.Calculate(
+            units::volt_t{m_rightUltrasonicSim.GetVoltage()} * 1_m / 1_V);
+    }
+}
+
+void Drivetrain::AddTrajectory(const frc::Pose2d& start,
+                               const std::vector<frc::Translation2d>& interior,
+                               const frc::Pose2d& end) {
+    m_controller.AddTrajectory(start, interior, end);
+}
+
+void Drivetrain::AddTrajectory(const frc::Pose2d& start,
+                               const std::vector<frc::Translation2d>& interior,
+                               const frc::Pose2d& end,
+                               const frc::TrajectoryConfig& config) {
+    m_controller.AddTrajectory(start, interior, end, config);
+}
+
+void Drivetrain::AddTrajectory(const std::vector<frc::Pose2d>& waypoints) {
+    m_controller.AddTrajectory(waypoints);
+}
+
+void Drivetrain::AddTrajectory(const std::vector<frc::Pose2d>& waypoints,
+                               const frc::TrajectoryConfig& config) {
+    m_controller.AddTrajectory(waypoints, config);
+}
+
+frc::TrajectoryConfig Drivetrain::MakeTrajectoryConfig() {
+    return DrivetrainController::MakeTrajectoryConfig();
+}
+
+frc::TrajectoryConfig Drivetrain::MakeTrajectoryConfig(
+    units::meters_per_second_t startVelocity,
+    units::meters_per_second_t endVelocity) {
+    return DrivetrainController::MakeTrajectoryConfig(startVelocity,
+                                                      endVelocity);
+}
+
+bool Drivetrain::AtGoal() const { return m_controller.AtGoal(); }
+
+const Eigen::Vector<double, 7>& Drivetrain::GetStates() const {
+    return m_observer.Xhat();
+}
+
+const Eigen::Vector<double, 2>& Drivetrain::GetInputs() const {
+    return m_controller.GetInputs();
+}
+
+units::ampere_t Drivetrain::GetCurrentDraw() const {
+    return m_drivetrainSim.GetCurrentDraw();
+}
+
+frc::Pose2d Drivetrain::GetSimPose() const { return m_drivetrainSim.GetPose(); }
+
+void Drivetrain::DisabledInit() {
+    SetCoastMode();
+    Disable();
+}
+
+void Drivetrain::AutonomousInit() {
+    SetBrakeMode();
+    Enable();
+}
+
+void Drivetrain::TeleopInit() {
+    SetBrakeMode();
+
+    // If the robot was disabled while still following a trajectory in
+    // autonomous, it will continue to do so in teleop. This aborts any
+    // trajectories so teleop driving can occur.
+    m_controller.AbortTrajectories();
+
+    Enable();
+}
+
+void Drivetrain::TestInit() {
+    SetBrakeMode();
+
+    // If the robot was disabled while still following a trajectory in
+    // autonomous, it will continue to do so in teleop. This aborts any
+    // trajectories so teleop driving can occur.
+    m_controller.AbortTrajectories();
+
+    Enable();
+}
+
+void Drivetrain::TeleopPeriodic() {
+    using Input = DrivetrainController::Input;
+
+    static frc::Joystick driveStick1{HWConfig::kDriveStick1Port};
+    static frc::Joystick driveStick2{HWConfig::kDriveStick2Port};
+
+    double y =
+        frc::ApplyDeadband(-driveStick1.GetY(), Constants::kJoystickDeadband);
+    double x =
+        frc::ApplyDeadband(driveStick2.GetX(), Constants::kJoystickDeadband);
+
+    if (driveStick1.GetRawButton(1)) {
+        y *= 0.5;
+        x *= 0.5;
+    }
+    auto [left, right] = frc::DifferentialDrive::CurvatureDriveIK(
+        y, x, driveStick2.GetRawButton(2));
+
+    // Implicit model following
+    // TODO: Velocities need filtering
+    Eigen::Vector<double, 2> u =
+        m_imf.Calculate(Eigen::Vector<double, 2>{GetLeftVelocity().value(),
+                                                 GetRightVelocity().value()},
+                        Eigen::Vector<double, 2>{left * 12.0, right * 12.0});
+
+    m_leftGrbx.SetVoltage(units::volt_t{u(Input::kLeftVoltage)});
+    m_rightGrbx.SetVoltage(units::volt_t{u(Input::kRightVoltage)});
+}
+
+void Drivetrain::TestPeriodic() {
+    using Input = DrivetrainController::Input;
+
+    static frc::Joystick driveStick1{HWConfig::kDriveStick1Port};
+    static frc::Joystick driveStick2{HWConfig::kDriveStick2Port};
+
+    double y =
+        frc::ApplyDeadband(-driveStick1.GetY(), Constants::kJoystickDeadband);
+    double x =
+        frc::ApplyDeadband(driveStick2.GetX(), Constants::kJoystickDeadband);
+
+    if (driveStick1.GetRawButton(1)) {
+        y *= 0.5;
+        x *= 0.5;
+    }
+    auto [left, right] = frc::DifferentialDrive::CurvatureDriveIK(
+        y, x, driveStick2.GetRawButton(2));
+
+    // Implicit model following
+    // TODO: Velocities need filtering
+    Eigen::Vector<double, 2> u =
+        m_imf.Calculate(Eigen::Vector<double, 2>{GetLeftVelocity().value(),
+                                                 GetRightVelocity().value()},
+                        Eigen::Vector<double, 2>{left * 12.0, right * 12.0});
+
+    m_leftGrbx.SetVoltage(units::volt_t{u(Input::kLeftVoltage)});
+    m_rightGrbx.SetVoltage(units::volt_t{u(Input::kRightVoltage)});
+}
+
+void Drivetrain::SetBrakeMode() {
+    m_leftLeader.SetIdleMode(rev::CANSparkMax::IdleMode::kBrake);
+    m_leftFollower.SetIdleMode(rev::CANSparkMax::IdleMode::kBrake);
+    m_rightLeader.SetIdleMode(rev::CANSparkMax::IdleMode::kBrake);
+    m_rightFollower.SetIdleMode(rev::CANSparkMax::IdleMode::kBrake);
+}
+
+void Drivetrain::SetCoastMode() {
+    m_leftLeader.SetIdleMode(rev::CANSparkMax::IdleMode::kCoast);
+    m_leftFollower.SetIdleMode(rev::CANSparkMax::IdleMode::kCoast);
+    m_rightLeader.SetIdleMode(rev::CANSparkMax::IdleMode::kCoast);
+    m_rightFollower.SetIdleMode(rev::CANSparkMax::IdleMode::kCoast);
+}

--- a/src/main/include/CANSparkMaxUtil.hpp
+++ b/src/main/include/CANSparkMaxUtil.hpp
@@ -1,0 +1,25 @@
+// Copyright (c) FRC Team 3512. All Rights Reserved.
+
+#pragma once
+
+#include <rev/CANSparkMax.h>
+
+namespace frc3512 {
+
+enum class Usage { kAll, kPositionOnly, kVelocityOnly, kMinimal };
+
+/**
+ * This function allows reducing a Spark Max's CAN bus utilization by reducing
+ * the periodic status frame period of nonessential frames from 20ms to 500ms.
+ *
+ * See
+ * https://docs.revrobotics.com/sparkmax/operating-modes/control-interfaces#periodic-status-frames
+ * for a description of the status frames.
+ *
+ * @param motor The motor to adjust the status frame periods on.
+ * @param usage The status frame feedack to enable. kAll is the default
+ *              when a CANSparkMax is constructed.
+ */
+void SetCANSparkMaxBusUsage(rev::CANSparkMax& motor, Usage usage);
+
+}  // namespace frc3512

--- a/src/main/include/HWConfig.hpp
+++ b/src/main/include/HWConfig.hpp
@@ -2,4 +2,115 @@
 
 #pragma once
 
-namespace frc3512::HWConfig {}  // namespace frc3512::HWConfig
+/**
+ * The hardware configuration namespace is for joystick ports and roboRIO
+ * channel assignments.
+ *
+ * Other hardware configuration constants that won't change often and belong to
+ * only one subsystem (like gear ratios) should be defined in the subsystem
+ * itself instead.
+ */
+namespace frc3512::HWConfig {
+
+/// Drive joystick 1 port
+constexpr int kDriveStick1Port = 0;
+
+/// Drive joystick 2 port
+constexpr int kDriveStick2Port = 1;
+
+/// Appendage joystick 1 port
+constexpr int kAppendageStick1Port = 2;
+
+/// Appendage joystick 2 port
+constexpr int kAppendageStick2Port = 3;
+
+namespace Drivetrain {
+/// Left motor leader CAN ID
+constexpr int kLeftMotorLeaderID = 16;
+
+/// Left motor follower CAN ID
+constexpr int kLeftMotorFollowerID = 1;
+
+/// Right motor leader CAN ID
+constexpr int kRightMotorLeaderID = 14;
+
+/// Right motor follower CAN ID
+constexpr int kRightMotorFollowerID = 15;
+
+// Encoder channels
+constexpr int kLeftEncoderA = 0;
+constexpr int kLeftEncoderB = 1;
+constexpr int kRightEncoderA = 2;
+constexpr int kRightEncoderB = 3;
+
+/// Left ultrasonic sensor channel
+constexpr int kLeftUltrasonicChannel = 3;
+
+/// Right ultrasonic sensor channel
+constexpr int kRightUltrasonicChannel = 2;
+}  // namespace Drivetrain
+
+namespace Flywheel {
+/// Left motor CAN ID
+constexpr int kLeftMotorID = 9;
+
+/// Right motor CAN ID
+constexpr int kRightMotorID = 10;
+
+/// Encoder channel A
+constexpr int kEncoderA = 6;
+
+/// Encoder channel B
+constexpr int kEncoderB = 7;
+}  // namespace Flywheel
+
+namespace Turret {
+/// Turret motor CAN ID
+constexpr int kMotorID = 8;
+
+/// Counterclockwise hall sensor digital input channel
+constexpr int kCCWHallChannel = 0;
+
+/// Clockwise hall sensor digital input channel
+constexpr int kCWHallChannel = 1;
+
+// Encoder digital input channel
+constexpr int kEncoderChannel = 8;
+}  // namespace Turret
+
+namespace Intake {
+/// Arm motor CAN ID
+constexpr int kArmMotorID = 6;
+
+/// Conveyor motor CAN ID
+constexpr int kConveyorMotorID = 7;
+
+/// Funnel motor CAN ID
+constexpr int kFunnelLeftMotorID = 4;
+constexpr int kFunnelRightMotorID = 5;
+
+/// Lower proximity sensor digital input channel
+constexpr int kLowerSensorChannel = 4;
+
+/// Upper proximity sensor digital input channel
+constexpr int kUpperSensorChannel = 5;
+
+/// Arm solenoid channel
+constexpr int kArmChannel = 0;
+}  // namespace Intake
+
+namespace Climber {
+/// Elevator motor CAN ID
+constexpr int kElevatorMotorID = 3;
+
+/// Traverser motor CAN ID
+constexpr int kTraverserMotorID = 13;
+
+/// Climber lock solenoid channel
+constexpr int kClimberLockChannel = 3;
+
+/// Climber color sensor arm servo channel
+constexpr int kColorSensorArmServoChannel = 9;
+}  // namespace Climber
+
+}  // namespace frc3512::HWConfig

--- a/src/main/include/LerpTable.hpp
+++ b/src/main/include/LerpTable.hpp
@@ -1,0 +1,86 @@
+// Copyright (c) FRC Team 3512. All Rights Reserved.
+
+#pragma once
+
+#include <map>
+#include <utility>
+
+namespace frc3512 {
+
+/**
+ * Implements a table of key-value pairs with linear interpolation between
+ * values.
+ *
+ * If there's no matching key, the value returned will be a linear interpolation
+ * between the keys before and after the provided one.
+ *
+ * @tparam Key   The key type.
+ * @tparam Value The value type.
+ */
+template <typename Key, typename Value>
+class LerpTable {
+public:
+    /**
+     * Inserts a key-value pair.
+     *
+     * @param key   The key.
+     * @param value The value.
+     */
+    void Insert(const Key& key, const Value& value) {
+        m_container.insert(std::make_pair(key, value));
+    }
+
+    /**
+     * Inserts a key-value pair.
+     *
+     * @param key   The key.
+     * @param value The value.
+     */
+    void Insert(Key&& key, Value&& value) {
+        m_container.insert(std::make_pair(key, value));
+    }
+
+    /**
+     * Returns the value associated with a given key.
+     *
+     * If there's no matching key, the value returned will be a linear
+     * interpolation between the keys before and after the provided one.
+     *
+     * @param key The key.
+     */
+    Value operator[](const Key& key) const {
+        using const_iterator = typename std::map<Key, Value>::const_iterator;
+
+        // Get iterator to upper bound key-value pair for the given key
+        const_iterator upper = m_container.upper_bound(key);
+
+        // If key > largest key in table, return value for largest table key
+        if (upper == m_container.end()) {
+            return (--upper)->second;
+        }
+
+        // If key <= smallest key in table, return value for smallest table key
+        if (upper == m_container.begin()) {
+            return upper->second;
+        }
+
+        // Get iterator to lower bound key-value pair
+        const_iterator lower = upper;
+        --lower;
+
+        // Perform linear interpolation between lower and upper bound
+        const double delta =
+            (key - lower->first) / (upper->first - lower->first);
+        return delta * upper->second + (1.0 - delta) * lower->second;
+    }
+
+    /**
+     * Clears the contents.
+     */
+    void Clear() { m_container.clear(); }
+
+private:
+    std::map<Key, Value> m_container;
+};
+
+}  // namespace frc3512

--- a/src/main/include/Robot.hpp
+++ b/src/main/include/Robot.hpp
@@ -12,6 +12,8 @@
 #include <units/time.h>
 
 #include "AutonomousChooser.hpp"
+#include "NetworkTableUtil.hpp"
+#include "subsystems/Drivetrain.hpp"
 #include "subsystems/SubsystemBase.hpp"
 
 #if RUNNING_FRC_TESTS
@@ -42,7 +44,13 @@ namespace frc3512 {
  */
 class Robot : public frc::TimedRobot {
 public:
+    // The subsystem initialization order determines the controller run order.
+
+    /// Drivetrain subsystem.
+    Drivetrain drivetrain;
+
     Robot();
+
     ~Robot();
 
     /**
@@ -137,6 +145,14 @@ public:
     void ExpectAutonomousEndConds();
 
 private:
+    frc::Timer m_timer;
+
     AutonomousChooser m_autonChooser{"No-op", [=] { AutoNoOp(); }};
+
+    frc::CSVLogFile m_batteryLogger{"Battery", "Battery voltage (V)"};
+    frc::CSVLogFile m_eventLogger{"Events", "Event"};
+
+    nt::NetworkTableEntry m_batteryVoltageEntry =
+        NetworkTableUtil::MakeDoubleEntry("/Diagnostics/Robot/batteryVoltage");
 };
 }  // namespace frc3512

--- a/src/main/include/controllers/DrivetrainController.hpp
+++ b/src/main/include/controllers/DrivetrainController.hpp
@@ -1,0 +1,402 @@
+// Copyright (c) FRC Team 3512. All Rights Reserved.
+
+#pragma once
+
+#include <functional>
+#include <tuple>
+#include <vector>
+
+#include <frc/Timer.h>
+#include <frc/controller/ControlAffinePlantInversionFeedforward.h>
+#include <frc/geometry/Pose2d.h>
+#include <frc/system/LinearSystem.h>
+#include <frc/trajectory/Trajectory.h>
+#include <frc/trajectory/TrajectoryConfig.h>
+#include <units/angle.h>
+#include <units/angular_acceleration.h>
+#include <units/angular_velocity.h>
+#include <units/curvature.h>
+#include <units/length.h>
+#include <units/time.h>
+#include <units/velocity.h>
+#include <units/voltage.h>
+#include <wpi/numbers>
+
+#include "Constants.hpp"
+#include "LerpTable.hpp"
+#include "controllers/ControllerBase.hpp"
+
+namespace frc3512 {
+
+/**
+ * The drivetrain controller.
+ *
+ * The drivetrain uses a linear time-varying LQR for feedback control. Since the
+ * model is control-affine (the dynamics are nonlinear, but the control inputs
+ * provide a linear contribution), a plant inversion feedforward was used.
+ * Trajectories generated from splines provide the motion profile to follow.
+ *
+ * The linear time-varying controller has a similar form to the LQR, but the
+ * model used to compute the controller gain is the nonlinear model linearized
+ * around the drivetrain's current state. We precomputed gains for important
+ * places in our state-space, then interpolated between them with a LUT to save
+ * computational resources.
+ *
+ * We decided to control for longitudinal error and cross-track error in the
+ * chassis frame instead of x and y error in the global frame, so the state
+ * Jacobian simplified such that we only had to sweep velocities (-4m/s to
+ * 4m/s).
+ *
+ * See section 9.6 in Controls Engineering in FRC for a derivation of the
+ * control law we used shown in theorem 9.6.3.
+ */
+class DrivetrainController : public ControllerBase<7, 2, 4> {
+public:
+    /// The wheel radius.
+    static constexpr units::meter_t kWheelRadius = 3.05_in;
+
+    /// The drivetrain gear ratio from the encoder to the wheel.
+    static constexpr double kDriveGearRatio = 1.0 / 1.0;
+
+    /// Drivetrain distance per encoder pulse.
+    static constexpr double kDpP =
+        (2.0 * wpi::numbers::pi * kWheelRadius.value()) * kDriveGearRatio /
+        2048.0;
+
+    /// Drivetrain chassis width.
+    static constexpr units::meter_t kWidth = [] {
+        auto absoluteValue = [](auto arg) {
+            return arg > decltype(arg){0} ? arg : -1.0 * arg;
+        };
+
+        // These values were collected by rotating the robot in place and
+        // recording the encoder position and gyro heading measurements.
+        // Difference is final measurement minus initial measurement.
+        constexpr auto kLeftPosition = 2.18274_m - 0_m;
+        constexpr auto kRightPosition = (-1.0 * 2.19665_m) - 0_m;
+        constexpr auto kHeading = (-1.0 * 3.1219_rad) - 3.1415_rad;
+
+        return (absoluteValue(kLeftPosition) + absoluteValue(kRightPosition)) /
+               absoluteValue(kHeading) * 1_rad;
+    }();
+
+    /// Linear velocity system ID gain.
+    static constexpr auto kLinearV = 3.02_V / 1_mps;
+
+    /// Linear acceleration system ID gain.
+    static constexpr auto kLinearA = 0.642_V / 1_mps_sq;
+
+    /// Angular velocity system ID gain.
+    static constexpr auto kAngularV = 1.382_V / 1_mps;
+
+    /// Angular acceleration system ID gain.
+    static constexpr auto kAngularA = 0.08495_V / 1_mps_sq;
+
+    /// Maximum linear velocity.
+    static constexpr auto kMaxV = 12_V / kLinearV;
+
+    /// Maximum linear acceleration.
+    static constexpr auto kMaxA = 12_V / kLinearA;
+
+    /**
+     * States of the drivetrain system.
+     */
+    class State {
+    public:
+        /// X position in global coordinate frame.
+        static constexpr int kX = 0;
+
+        /// Y position in global coordinate frame.
+        static constexpr int kY = 1;
+
+        /// Heading in global coordinate frame.
+        static constexpr int kHeading = 2;
+
+        /// Left encoder velocity.
+        static constexpr int kLeftVelocity = 3;
+
+        /// Right encoder velocity.
+        static constexpr int kRightVelocity = 4;
+
+        /// Left encoder position.
+        static constexpr int kLeftPosition = 5;
+
+        /// Right encoder position.
+        static constexpr int kRightPosition = 6;
+    };
+
+    /**
+     * Inputs of the drivetrain system.
+     */
+    class Input {
+    public:
+        /// Left motor voltage.
+        static constexpr int kLeftVoltage = 0;
+
+        /// Right motor voltage.
+        static constexpr int kRightVoltage = 1;
+    };
+
+    /**
+     * Local outputs of the drivetrain system.
+     */
+    class LocalOutput {
+    public:
+        /// Heading in global coordinate frame.
+        static constexpr int kHeading = 0;
+
+        /// Left encoder position.
+        static constexpr int kLeftPosition = 1;
+
+        /// Right encoder position.
+        static constexpr int kRightPosition = 2;
+
+        /// Acceleration along X axis in chassis coordinate frame.
+        static constexpr int kAccelerationX = 3;
+
+        /// Acceleration along Y axis in chassis coordinate frame.
+        static constexpr int kAccelerationY = 4;
+    };
+
+    /**
+     * Global outputs of the drivetrain system.
+     */
+    class GlobalOutput {
+    public:
+        /// X position
+        static constexpr int kX = 0;
+
+        /// Y position
+        static constexpr int kY = 1;
+    };
+
+    /**
+     * Constructs a drivetrain controller.
+     */
+    DrivetrainController();
+
+    /**
+     * Move constructor.
+     */
+    DrivetrainController(DrivetrainController&&) = default;
+
+    /**
+     * Move assignment operator.
+     */
+    DrivetrainController& operator=(DrivetrainController&&) = default;
+
+    /**
+     * Adds a trajectory with the given waypoints.
+     *
+     * This can be called more than once to create a queue of trajectories.
+     * Closed-loop control will be enabled to track the first trajectory.
+     *
+     * @param start    Starting pose.
+     * @param interior Intermediate waypoints excluding heading.
+     * @param end      Ending pose.
+     * @param config   TrajectoryConfig for this trajectory. This can include
+     *                 constraints on the trajectory dynamics. If adding custom
+     *                 constraints, it is recommended to start with the config
+     *                 returned by MakeTrajectoryConfig() so differential drive
+     *                 dynamics constraints are included automatically.
+     */
+    void AddTrajectory(
+        const frc::Pose2d& start,
+        const std::vector<frc::Translation2d>& interior, const frc::Pose2d& end,
+        const frc::TrajectoryConfig& config = MakeTrajectoryConfig());
+
+    /**
+     * Adds a trajectory with the given waypoints.
+     *
+     * This can be called more than once to create a queue of trajectories.
+     * Closed-loop control will be enabled to track the first trajectory.
+     *
+     * @param waypoints Waypoints.
+     * @param config    TrajectoryConfig for this trajectory. This can include
+     *                  constraints on the trajectory dynamics. If adding custom
+     *                  constraints, it is recommended to start with the config
+     *                  returned by MakeTrajectoryConfig() so differential drive
+     *                  dynamics constraints are included automatically.
+     */
+    void AddTrajectory(
+        const std::vector<frc::Pose2d>& waypoints,
+        const frc::TrajectoryConfig& config = MakeTrajectoryConfig());
+
+    /**
+     * Returns true if drivetrain controller has a trajectory to follow.
+     */
+    bool HaveTrajectory() const;
+
+    /**
+     * Abort trajectory tracking.
+     */
+    void AbortTrajectories();
+
+    /**
+     * Returns whether the drivetrain controller is at the goal waypoint.
+     */
+    bool AtGoal() const;
+
+    /**
+     * Resets any internal state.
+     *
+     * @param initialPose Initial pose for state estimate.
+     */
+    void Reset(const frc::Pose2d& initialPose);
+
+    /**
+     * Returns the next output of the controller.
+     *
+     * @param x The current state x.
+     */
+    Eigen::Vector<double, 2> Calculate(
+        const Eigen::Vector<double, 7>& x) override;
+
+    /**
+     * Returns the drivetrain's plant.
+     */
+    static frc::LinearSystem<2, 2, 2> GetPlant();
+
+    /**
+     * Returns a TrajectoryConfig containing a differential drive dynamics
+     * constraint with the start and end velocities set to zero.
+     */
+    static frc::TrajectoryConfig MakeTrajectoryConfig();
+
+    /**
+     * Returns a TrajectoryConfig containing a differential drive dynamics
+     * constraint and the specified start and end velocities.
+     *
+     * @param startVelocity The start velocity of the trajectory config.
+     * @param endVelocity The end velocity of the trajectory config.
+     */
+    static frc::TrajectoryConfig MakeTrajectoryConfig(
+        units::meters_per_second_t startVelocity,
+        units::meters_per_second_t endVelocity);
+
+    /**
+     * Returns the linear time-varying controller gain for the given state.
+     *
+     * @param x The state vector.
+     */
+    Eigen::Matrix<double, 2, 5> ControllerGainForState(
+        const Eigen::Vector<double, 7>& x);
+
+    /**
+     * The linear time-varying control law.
+     *
+     * @param x The state vector.
+     * @param r The reference vector.
+     */
+    Eigen::Vector<double, 2> Controller(const Eigen::Vector<double, 7>& x,
+                                        const Eigen::Vector<double, 7>& r);
+
+    /**
+     * The drivetrain system dynamics.
+     *
+     * @param x The state vector.
+     * @param u The input vector.
+     */
+    static Eigen::Vector<double, 7> Dynamics(const Eigen::Vector<double, 7>& x,
+                                             const Eigen::Vector<double, 2>& u);
+
+    /**
+     * Returns the Jacobian of the pose and velocity dynamics with respect to
+     * the state vector.
+     *
+     * @param x The state vector.
+     */
+    static Eigen::Matrix<double, 5, 5> JacobianX(
+        const Eigen::Vector<double, 7>& x);
+
+    /**
+     * Returns the Jacobian of the pose and velocity dynamics with respect to
+     * the input vector.
+     *
+     * @param u The input vector.
+     */
+    static Eigen::Matrix<double, 5, 2> JacobianU(
+        const Eigen::Vector<double, 2>& u);
+
+    /**
+     * Returns the local measurements that correspond to the given state and
+     * input vectors.
+     *
+     * @param x The state vector.
+     * @param u The input vector.
+     */
+    static Eigen::Vector<double, 5> LocalMeasurementModel(
+        const Eigen::Vector<double, 7>& x, const Eigen::Vector<double, 2>& u);
+
+    /**
+     * Returns the global measurements that correspond to the given state and
+     * input vectors.
+     *
+     * @param x The state vector.
+     * @param u The input vector.
+     */
+    static Eigen::Vector<double, 2> GlobalMeasurementModel(
+        const Eigen::Vector<double, 7>& x, const Eigen::Vector<double, 2>& u);
+
+private:
+    static constexpr double kPositionTolerance = 0.5;  // meters
+    static constexpr double kVelocityTolerance = 2.0;  // meters/second
+    static constexpr double kAngleTolerance = 0.52;    // radians
+
+    static const frc::LinearSystem<2, 2, 2> kPlant;
+
+    frc::ControlAffinePlantInversionFeedforward<7, 2> m_ff{
+        Dynamics, Constants::kControllerPeriod};
+
+    Eigen::Matrix<double, 5, 5> m_A;
+    Eigen::Matrix<double, 5, 2> m_B;
+    Eigen::Matrix<double, 5, 5> m_Q =
+        frc::MakeCostMatrix(0.0625, 0.125, 2.5, 0.95, 0.95);
+    Eigen::Matrix<double, 2, 2> m_R = frc::MakeCostMatrix(12.0, 12.0);
+
+    // LUT from drivetrain linear velocity to LQR gain
+    LerpTable<units::meters_per_second_t, Eigen::Matrix<double, 2, 5>> m_table;
+
+    frc::Trajectory m_trajectory;
+    frc::Pose2d m_goal;
+    frc::Timer m_trajectoryTimeElapsed;
+
+    bool m_atReferences = false;
+
+    /**
+     * Update "at references" flag based on next reference and current state
+     * estimate.
+     *
+     * @param error The error vector.
+     */
+    void UpdateAtReferences(const Eigen::Vector<double, 5>& error);
+
+    /**
+     * Converts velocity and curvature of drivetrain into left and right wheel
+     * velocities.
+     *
+     * @param velocity Linear velocity of drivetrain chassis.
+     * @param curvature Curvature of drivetrain arc.
+     * @param trackWidth Track width of drivetrain.
+     */
+    static constexpr std::tuple<units::meters_per_second_t,
+                                units::meters_per_second_t>
+    ToWheelVelocities(units::meters_per_second_t velocity,
+                      units::curvature_t curvature, units::meter_t trackWidth) {
+        // v = (v_r + v_l) / 2     (1)
+        // w = (v_r - v_l) / (2r)  (2)
+        // k = w / v               (3)
+        //
+        // v_l = v - wr
+        // v_l = v - (vk)r
+        // v_l = v(1 - kr)
+        //
+        // v_r = v + wr
+        // v_r = v + (vk)r
+        // v_r = v(1 + kr)
+        auto vl = velocity * (1 - (curvature / 1_rad * trackWidth / 2.0));
+        auto vr = velocity * (1 + (curvature / 1_rad * trackWidth / 2.0));
+        return {vl, vr};
+    }
+};
+}  // namespace frc3512

--- a/src/main/include/controllers/ImplicitModelFollower.hpp
+++ b/src/main/include/controllers/ImplicitModelFollower.hpp
@@ -1,0 +1,193 @@
+// Copyright (c) FRC Team 3512. All Rights Reserved.
+
+#pragma once
+
+#include <algorithm>
+
+#include <Eigen/Cholesky>
+#include <Eigen/Core>
+#include <Eigen/Eigenvalues>
+#include <drake/math/discrete_algebraic_riccati_equation.h>
+#include <frc/StateSpaceUtil.h>
+#include <frc/controller/LinearQuadraticRegulator.h>
+#include <frc/system/Discretization.h>
+#include <frc/system/LinearSystem.h>
+#include <units/time.h>
+#include <wpi/array.h>
+
+namespace frc3512 {
+
+/**
+ * Contains the controller coefficients and logic for an implicit model
+ * follower.
+ *
+ * Implicit model following lets us design a feedback controller that erases the
+ * dynamics of our system and makes it behave like some other system. This can
+ * be used to make a drivetrain more controllable during teleop driving by
+ * making it behave like a slower or more benign drivetrain.
+ *
+ * For more on the underlying math, read appendix C.3 in
+ * https://file.tavsys.net/control/controls-engineering-in-frc.pdf.
+ */
+template <int States, int Inputs>
+class ImplicitModelFollower {
+public:
+    /**
+     * Constructs a controller with the given coefficients and plant.
+     *
+     * @param plant    The plant being controlled.
+     * @param plantRef The plant whose dynamics should be followed.
+     * @param Qelems   The maximum desired error tolerance for each state.
+     * @param Relems   The maximum desired control effort for each input.
+     * @param dt       Discretization timestep.
+     */
+    template <int Outputs>
+    ImplicitModelFollower(
+        const frc::LinearSystem<States, Inputs, Outputs>& plant,
+        const frc::LinearSystem<States, Inputs, Outputs>& plantRef,
+        const wpi::array<double, States>& Qelems,
+        const wpi::array<double, Inputs>& Relems, units::second_t dt)
+        : ImplicitModelFollower<States, Inputs>(plant.A(), plant.B(),
+                                                plantRef.A(), plantRef.B(),
+                                                Qelems, Relems, dt) {}
+
+    /**
+     * Constructs a controller with the given coefficients and plant.
+     *
+     * @param A      Continuous system matrix of the plant being controlled.
+     * @param B      Continuous input matrix of the plant being controlled.
+     * @param Aref   Continuous system matrix whose dynamics should be followed.
+     * @param Bref   Continuous input matrix whose dynamics should be followed.
+     * @param Qelems The maximum desired error tolerance for each state.
+     * @param Relems The maximum desired control effort for each input.
+     * @param dt     Discretization timestep.
+     */
+    ImplicitModelFollower(const Eigen::Matrix<double, States, States>& A,
+                          const Eigen::Matrix<double, States, Inputs>& B,
+                          const Eigen::Matrix<double, States, States>& Aref,
+                          const Eigen::Matrix<double, States, States>& Bref,
+                          const wpi::array<double, States>& Qelems,
+                          const wpi::array<double, Inputs>& Relems,
+                          units::second_t dt) {
+        // Discretize real dynamics
+        Eigen::Matrix<double, States, States> discA;
+        Eigen::Matrix<double, States, Inputs> discB;
+        frc::DiscretizeAB<States, Inputs>(A, B, dt, &discA, &discB);
+
+        // Discretize desired dynamics
+        Eigen::Matrix<double, States, States> discAref;
+        Eigen::Matrix<double, States, Inputs> discBref;
+        frc::DiscretizeAB<States, Inputs>(Aref, Bref, dt, &discAref, &discBref);
+
+        // Find initial Q and R weights
+        Eigen::Matrix<double, States, States> Q = frc::MakeCostMatrix(Qelems);
+        Eigen::Matrix<double, Inputs, Inputs> R = frc::MakeCostMatrix(Relems);
+
+        Eigen::Matrix<double, States, States> Adiff = discA - discAref;
+
+        Eigen::Matrix<double, States, States> Qimf =
+            Adiff.transpose() * Q * Adiff;
+        Eigen::Matrix<double, Inputs, Inputs> Rimf =
+            discB.transpose() * Q * discB + R;
+        Eigen::Matrix<double, States, Inputs> Nimf =
+            Adiff.transpose() * Q * discB;
+
+        // Nudge eigenvalues of Qimf slightly more positive if Q <= 0, since
+        // this is usually caused by numerical imprecision
+        Eigen::SelfAdjointEigenSolver<decltype(Qimf)> Qeigen{Qimf};
+        if (!std::all_of(Qeigen.eigenvalues().data(),
+                         Qeigen.eigenvalues().data() + States,
+                         [](const auto& elem) { return elem >= 0.0; })) {
+            Qimf += decltype(Qimf)::Identity() * 1e-10;
+        }
+
+        Eigen::Matrix<double, States, States> S =
+            drake::math::DiscreteAlgebraicRiccatiEquation(discA, discB, Qimf,
+                                                          Rimf, Nimf);
+
+        // K = (BᵀSB + R)⁻¹(BᵀSA + Nᵀ)
+        m_K = (discB.transpose() * S * discB + Rimf)
+                  .llt()
+                  .solve(discB.transpose() * S * discA + Nimf.transpose());
+
+        // Find u_imf that makes real model match reference model.
+        //
+        // x_k+1 = Ax_k + Bu_imf
+        // z_k+1 = Aref z_k + Bref u_k
+        //
+        // Let x_k = z_k.
+        //
+        // x_k+1 = z_k+1
+        // Ax_k + Bu_imf = Aref x_k + Bref u_k
+        // Bu_imf = Aref x_k - Ax_k + Bref u_k
+        // Bu_imf = (Aref - A)x_k + Bref u_k
+        // u_imf = B^+ ((Aref - A)x_k + Bref u_k)
+        // u_imf = -B^+ (A - Aref)x_k + B^+ Bref u_k
+
+        // The first term makes the open-loop poles that of the reference
+        // system, and the second term makes the input behave like that of the
+        // reference system.
+        m_B = discB.householderQr().solve(discBref);
+
+        Reset();
+    }
+
+    /**
+     * Returns the controller matrix K.
+     */
+    const Eigen::Matrix<double, Inputs, States>& K() const { return m_K; }
+
+    /**
+     * Returns an element of the controller matrix K.
+     *
+     * @param i Row of K.
+     * @param j Column of K.
+     */
+    double K(int i, int j) const { return m_K(i, j); }
+
+    /**
+     * Returns the control input vector u.
+     *
+     * @return The control input.
+     */
+    const Eigen::Vector<double, Inputs>& U() const { return m_u; }
+
+    /**
+     * Returns an element of the control input vector u.
+     *
+     * @param i Row of u.
+     *
+     * @return The row of the control input vector.
+     */
+    double U(int i) const { return m_u(i, 0); }
+
+    /**
+     * Resets the controller.
+     */
+    void Reset() { m_u.setZero(); }
+
+    /**
+     * Returns the next output of the controller.
+     *
+     * @param x The current state x.
+     * @param u The current input for the original model.
+     */
+    Eigen::Vector<double, Inputs> Calculate(
+        const Eigen::Vector<double, States>& x,
+        const Eigen::Vector<double, Inputs>& u) {
+        m_u = -m_K * x + m_B * u;
+        return m_u;
+    }
+
+private:
+    // Computed controller output
+    Eigen::Vector<double, Inputs> m_u;
+
+    // Controller gain
+    Eigen::Matrix<double, Inputs, States> m_K;
+
+    // Input space conversion gain
+    Eigen::Matrix<double, Inputs, Inputs> m_B;
+};
+
+}  // namespace frc3512

--- a/src/main/include/logging/CSVControllerLogger.hpp
+++ b/src/main/include/logging/CSVControllerLogger.hpp
@@ -3,10 +3,12 @@
 #pragma once
 
 #include <array>
+#include <string_view>
 #include <tuple>
 #include <utility>
 
 #include <Eigen/Core>
+#include <fmt/format.h>
 #include <frc/logging/CSVLogFile.h>
 #include <units/time.h>
 
@@ -36,12 +38,12 @@ public:
         const std::array<ControllerLabel, States>& stateLabels,
         const std::array<ControllerLabel, Inputs>& inputLabels,
         const std::array<ControllerLabel, Outputs>& outputLabels)
-        : m_stateLogger{(controllerName + " states").str(),
+        : m_stateLogger{fmt::format("{} states", controllerName),
                         std::tuple_cat(MakeReferenceLabels(stateLabels),
                                        MakeStateEstimateLabels(stateLabels))},
-          m_inputLogger{(controllerName + " inputs").str(),
+          m_inputLogger{fmt::format("{} inputs", controllerName),
                         MakeInputLabels(inputLabels)},
-          m_outputLogger{(controllerName + " outputs").str(),
+          m_outputLogger{fmt::format("{} outputs", controllerName),
                          MakeOutputLabels(outputLabels)} {}
 
     /**

--- a/src/main/include/logging/ControllerLabel.hpp
+++ b/src/main/include/logging/ControllerLabel.hpp
@@ -3,6 +3,7 @@
 #pragma once
 
 #include <string>
+#include <string_view>
 
 namespace frc3512 {
 

--- a/src/main/include/logging/NTControllerLogger.hpp
+++ b/src/main/include/logging/NTControllerLogger.hpp
@@ -3,9 +3,10 @@
 #pragma once
 
 #include <array>
-#include <string>
+#include <string_view>
 
 #include <Eigen/Core>
+#include <fmt/format.h>
 #include <networktables/NetworkTableEntry.h>
 #include <networktables/NetworkTableInstance.h>
 
@@ -35,26 +36,24 @@ public:
         const std::array<ControllerLabel, States>& stateLabels,
         const std::array<ControllerLabel, Inputs>& inputLabels,
         const std::array<ControllerLabel, Outputs>& outputLabels) {
-        std::string entryPrefix = fmt::format("/Diagnostics/" + controllerName);
-
         nt::NetworkTableInstance instance =
             nt::NetworkTableInstance::GetDefault();
         for (int state = 0; state < States; ++state) {
             const auto& label = stateLabels[state];
-            m_refEntries[state] =
-                instance.GetEntry(entryPrefix + "/References/" + label.name);
-            m_stateEntries[state] =
-                instance.GetEntry(entryPrefix + "/States/" + label.name);
+            m_refEntries[state] = instance.GetEntry(fmt::format(
+                "/Diagnostics/{}/References/{}", controllerName, label.name));
+            m_stateEntries[state] = instance.GetEntry(fmt::format(
+                "/Diagnostics/{}/States/{}", controllerName, label.name));
         }
         for (int input = 0; input < Inputs; ++input) {
             const auto& label = inputLabels[input];
-            m_inputEntries[input] =
-                instance.GetEntry(entryPrefix + "/Inputs/" + label.name);
+            m_inputEntries[input] = instance.GetEntry(fmt::format(
+                "/Diagnostics/{}/Inputs/{}", controllerName, label.name));
         }
         for (int output = 0; output < Outputs; ++output) {
             const auto& label = outputLabels[output];
-            m_outputEntries[output] =
-                instance.GetEntry(entryPrefix + "/Outputs/" + label.name);
+            m_outputEntries[output] = instance.GetEntry(fmt::format(
+                "/Diagnostics/{}/Outputs/{}", controllerName, label.name));
         }
     }
 
@@ -76,10 +75,10 @@ public:
      * @param u Input vector.
      * @param y Output vector.
      */
-    void Log(const Eigen::Matrix<double, States, 1>& r,
-             const Eigen::Matrix<double, States, 1>& x,
-             const Eigen::Matrix<double, Inputs, 1>& u,
-             const Eigen::Matrix<double, Outputs, 1>& y) {
+    void Log(const Eigen::Vector<double, States>& r,
+             const Eigen::Vector<double, States>& x,
+             const Eigen::Vector<double, Inputs>& u,
+             const Eigen::Vector<double, Outputs>& y) {
         for (int state = 0; state < States; ++state) {
             m_refEntries[state].SetDouble(r(state));
             m_stateEntries[state].SetDouble(x(state));

--- a/src/main/include/static_concurrent_queue.hpp
+++ b/src/main/include/static_concurrent_queue.hpp
@@ -1,0 +1,111 @@
+// Copyright (c) FRC Team 3512. All Rights Reserved.
+
+#pragma once
+
+#include <cstddef>
+#include <optional>
+#include <utility>
+
+#include <wpi/mutex.h>
+#include <wpi/static_circular_buffer.h>
+
+namespace frc3512 {
+
+/**
+ * Implements a thread-safe FIFO queue with a circular buffer as the storage.
+ */
+template <typename T, size_t N>
+class static_concurrent_queue {
+public:
+    /**
+     * Returns true if the queue is empty.
+     */
+    bool empty() const {
+        std::scoped_lock lock(m_mutex);
+        return m_queue.size() > 0;
+    }
+
+    /**
+     * Returns the number of elements in the queue.
+     */
+    size_t size() const {
+        std::scoped_lock lock(m_mutex);
+        return m_queue.size();
+    }
+
+    /**
+     * Returns the element at the front of the queue or std::nullopt_t if the
+     * queue was empty.
+     */
+    std::optional<T> pop() {
+        std::unique_lock lock(m_mutex);
+        if (m_queue.size() > 0) {
+            return m_queue.pop_back();
+        } else {
+            return std::nullopt;
+        }
+    }
+
+    /**
+     * Pushes an element into the back of the queue.
+     *
+     * @param item The element to push.
+     */
+    void push(const T& item) {
+        std::scoped_lock lock(m_mutex);
+        m_queue.push_front(item);
+    }
+
+    /**
+     * Pushes an element into the back of the queue.
+     *
+     * @param item The element to push.
+     */
+    void push(T&& item) {
+        std::scoped_lock lock(m_mutex);
+        m_queue.push_front(std::forward<T>(item));
+    }
+
+    /**
+     * Constructs an element with the given arguments and pushes it into the
+     * back of the queue.
+     *
+     * @param args The arguments to use when constructing the element.
+     */
+    template <typename... Args>
+    void emplace(Args&&... args) {
+        std::scoped_lock lock(m_mutex);
+        m_queue.emplace_front(std::forward<Args>(args)...);
+    }
+
+    /**
+     * Clears the queue.
+     */
+    void reset() {
+        std::scoped_lock lock(m_mutex);
+        m_queue.reset();
+    }
+
+    static_concurrent_queue() = default;
+
+    /**
+     * Move constructor.
+     */
+    static_concurrent_queue(static_concurrent_queue&& rhs) {
+        std::swap(m_queue, rhs.m_queue);
+    }
+
+    /**
+     * Move assignment operator.
+     */
+    static_concurrent_queue& operator=(static_concurrent_queue&& rhs) {
+        std::swap(m_queue, rhs.m_queue);
+        return *this;
+    }
+
+private:
+    wpi::static_circular_buffer<T, N> m_queue;
+    mutable wpi::mutex m_mutex;
+};
+
+}  // namespace frc3512

--- a/src/main/include/subsystems/ControlledSubsystemBase.hpp
+++ b/src/main/include/subsystems/ControlledSubsystemBase.hpp
@@ -9,6 +9,7 @@
 
 #include <Eigen/Core>
 #include <fmt/core.h>
+#include <fmt/format.h>
 #include <frc/DriverStation.h>
 #include <frc/RobotBase.h>
 #include <frc/Threads.h>
@@ -58,7 +59,7 @@ public:
         const std::array<ControllerLabel, Outputs>& outputLabels)
         : m_csvLogger{controllerName, stateLabels, inputLabels, outputLabels},
           m_ntLogger{controllerName, stateLabels, inputLabels, outputLabels},
-          m_timingLogger{(controllerName + " timing").str(),
+          m_timingLogger{fmt::format("{} timing", controllerName),
                          "Loop duration (ms)", "Scheduling period (ms)"} {
         m_entryThreadRunning = true;
         m_entryThread = std::thread{[=] { EntryThreadMain(); }};
@@ -87,7 +88,7 @@ public:
         // m_lastTime is reset so that a large time delta isn't generated from
         // Update() not being called in a while.
         m_lastTime =
-            frc2::Timer::GetFPGATimestamp() - Constants::kControllerPeriod;
+            frc::Timer::GetFPGATimestamp() - Constants::kControllerPeriod;
         m_isEnabled = true;
     }
 
@@ -115,7 +116,7 @@ public:
      * Computes current timestep's dt.
      */
     void UpdateDt() {
-        m_nowBegin = frc2::Timer::GetFPGATimestamp();
+        m_nowBegin = frc::Timer::GetFPGATimestamp();
         m_dt = m_nowBegin - m_lastTime;
 
         if (m_dt == 0_s) {
@@ -141,7 +142,7 @@ public:
              const Eigen::Matrix<double, States, 1>& x,
              const Eigen::Matrix<double, Inputs, 1>& u,
              const Eigen::Matrix<double, Outputs, 1>& y) {
-        m_entryQueue.emplace(m_nowBegin, frc2::Timer::GetFPGATimestamp(), r, x,
+        m_entryQueue.emplace(m_nowBegin, frc::Timer::GetFPGATimestamp(), r, x,
                              u, y);
         m_lastTime = m_nowBegin;
     }

--- a/src/main/include/subsystems/Drivetrain.hpp
+++ b/src/main/include/subsystems/Drivetrain.hpp
@@ -1,0 +1,351 @@
+// Copyright (c) FRC Team 3512. All Rights Reserved.
+
+#pragma once
+
+#include <vector>
+
+#include <Eigen/Core>
+#include <frc/ADIS16470_IMU.h>
+#include <frc/AnalogInput.h>
+#include <frc/Encoder.h>
+#include <frc/estimator/AngleStatistics.h>
+#include <frc/estimator/KalmanFilterLatencyCompensator.h>
+#include <frc/estimator/UnscentedKalmanFilter.h>
+#include <frc/filter/LinearFilter.h>
+#include <frc/geometry/Pose2d.h>
+#include <frc/geometry/Translation2d.h>
+#include <frc/motorcontrol/MotorControllerGroup.h>
+#include <frc/simulation/ADIS16470_IMUSim.h>
+#include <frc/simulation/AnalogInputSim.h>
+#include <frc/simulation/DifferentialDrivetrainSim.h>
+#include <frc/simulation/EncoderSim.h>
+#include <frc/smartdashboard/Field2d.h>
+#include <frc/system/plant/LinearSystemId.h>
+#include <frc/trajectory/TrajectoryConfig.h>
+#include <networktables/NetworkTableEntry.h>
+#include <rev/CANSparkMax.h>
+#include <units/acceleration.h>
+#include <units/angle.h>
+#include <units/angular_velocity.h>
+#include <units/current.h>
+#include <units/length.h>
+#include <units/time.h>
+#include <units/velocity.h>
+
+#include "Constants.hpp"
+#include "HWConfig.hpp"
+#include "NetworkTableUtil.hpp"
+#include "controllers/DrivetrainController.hpp"
+#include "controllers/ImplicitModelFollower.hpp"
+#include "static_concurrent_queue.hpp"
+#include "subsystems/ControlledSubsystemBase.hpp"
+
+namespace frc3512 {
+
+/**
+ * The drivetrain subsystem.
+ *
+ * The drivetrain uses an unscented Kalman filter for state estimation.
+ */
+class Drivetrain : public ControlledSubsystemBase<7, 2, 5> {
+public:
+    /// The drivetrain length.
+    static constexpr units::meter_t kLength = 0.9398_m;
+
+    /**
+     * Distance from middle of robot to intake.
+     */
+    static constexpr units::meter_t kMiddleOfRobotToIntake = 0.656_m;
+
+    Drivetrain();
+
+    Drivetrain(const Drivetrain&) = delete;
+    Drivetrain& operator=(const Drivetrain&) = delete;
+
+    /**
+     * Returns the drivetrain's reference pose.
+     */
+    frc::Pose2d GetReferencePose() const;
+
+    /**
+     * Returns the drivetrain's pose estimate.
+     */
+    frc::Pose2d GetPose() const;
+
+    /**
+     * Returns distance from the left ultrasonic sensor.
+     */
+    units::meter_t GetLeftUltrasonicDistance() const;
+
+    /**
+     * Returns distance from the right ultrasonic sensor.
+     */
+    units::meter_t GetRightUltrasonicDistance() const;
+
+    /**
+     * Returns gyro's heading measurement in the global coordinate frame.
+     */
+    units::radian_t GetAngle() const;
+
+    /**
+     * Returns left encoder displacement.
+     */
+    units::meter_t GetLeftPosition() const;
+
+    /**
+     * Returns right encoder displacement.
+     */
+    units::meter_t GetRightPosition() const;
+
+    /**
+     * Returns left encoder velocity.
+     */
+    units::meters_per_second_t GetLeftVelocity() const;
+
+    /**
+     * Returns right encoder velocity.
+     */
+    units::meters_per_second_t GetRightVelocity() const;
+
+    /**
+     * Returns longitudinal acceleration from IMU.
+     */
+    units::meters_per_second_squared_t GetAccelerationX() const;
+
+    /**
+     * Returns lateral acceleration from IMU.
+     */
+    units::meters_per_second_squared_t GetAccelerationY() const;
+
+    /**
+     * Resets all sensors and controller.
+     */
+    void Reset(const frc::Pose2d& initialPose = frc::Pose2d());
+
+    /**
+     * Set global measurements.
+     *
+     * @param x         X position of the robot in meters.
+     * @param y         Y position of the robot in meters.
+     * @param timestamp Absolute time the translation data comes from.
+     */
+    void CorrectWithGlobalOutputs(units::meter_t x, units::meter_t y,
+                                  units::second_t timestamp);
+
+    /**
+     * Adds a trajectory with the given waypoints.
+     *
+     * This can be called more than once to create a queue of trajectories.
+     * Closed-loop control will be enabled to track the first trajectory.
+     *
+     * @param start    Starting pose.
+     * @param interior Intermediate waypoints excluding heading.
+     * @param end      Ending pose.
+     */
+    void AddTrajectory(const frc::Pose2d& start,
+                       const std::vector<frc::Translation2d>& interior,
+                       const frc::Pose2d& end);
+
+    /**
+     * Adds a trajectory with the given waypoints.
+     *
+     * This can be called more than once to create a queue of trajectories.
+     * Closed-loop control will be enabled to track the first trajectory.
+     *
+     * @param start    Starting pose.
+     * @param interior Intermediate waypoints excluding heading.
+     * @param end      Ending pose.
+     * @param config   TrajectoryConfig for this trajectory. This can include
+     *                 constraints on the trajectory dynamics. If adding custom
+     *                 constraints, it is recommended to start with the config
+     *                 returned by MakeTrajectoryConfig() so differential drive
+     *                 dynamics constraints are included automatically.
+     */
+    void AddTrajectory(const frc::Pose2d& start,
+                       const std::vector<frc::Translation2d>& interior,
+                       const frc::Pose2d& end,
+                       const frc::TrajectoryConfig& config);
+
+    /**
+     * Adds a trajectory with the given waypoints.
+     *
+     * This can be called more than once to create a queue of trajectories.
+     * Closed-loop control will be enabled to track the first trajectory.
+     *
+     * @param waypoints Waypoints.
+     */
+    void AddTrajectory(const std::vector<frc::Pose2d>& waypoints);
+
+    /**
+     * Adds a trajectory with the given waypoints.
+     *
+     * This can be called more than once to create a queue of trajectories.
+     * Closed-loop control will be enabled to track the first trajectory.
+     *
+     * @param waypoints Waypoints.
+     * @param config    TrajectoryConfig for this trajectory. This can include
+     *                  constraints on the trajectory dynamics. If adding custom
+     *                  constraints, it is recommended to start with the config
+     *                  returned by MakeTrajectoryConfig() so differential drive
+     *                  dynamics constraints are included automatically.
+     */
+    void AddTrajectory(const std::vector<frc::Pose2d>& waypoints,
+                       const frc::TrajectoryConfig& config);
+
+    /**
+     * Returns a TrajectoryConfig containing a differential drive dynamics
+     * constraint with the start and end velocities set to zero.
+     */
+    static frc::TrajectoryConfig MakeTrajectoryConfig();
+
+    /**
+     * Returns a TrajectoryConfig containing a differential drive dynamics
+     * constraint and the specified start and end velocities.
+     *
+     * @param startVelocity The start velocity of the trajectory.
+     * @param endVelocity   The end velocity of the trajectory.
+     */
+    static frc::TrajectoryConfig MakeTrajectoryConfig(
+        units::meters_per_second_t startVelocity,
+        units::meters_per_second_t endVelocity);
+
+    /**
+     * Returns whether the drivetrain controller is at the goal waypoint.
+     */
+    bool AtGoal() const;
+
+    /**
+     * Returns the drivetrain state estimate.
+     */
+    const Eigen::Vector<double, 7>& GetStates() const;
+
+    /**
+     * Returns the drivetrain inputs.
+     */
+    const Eigen::Vector<double, 2>& GetInputs() const;
+
+    /**
+     * Returns current drawn in simulation.
+     */
+    units::ampere_t GetCurrentDraw() const;
+
+    /**
+     * Returns sim pose.
+     */
+    frc::Pose2d GetSimPose() const;
+
+    void DisabledInit() override;
+
+    void AutonomousInit() override;
+
+    void TeleopInit() override;
+
+    void TestInit() override;
+
+    void RobotPeriodic() override;
+
+    void TeleopPeriodic() override;
+
+    void TestPeriodic() override;
+
+    void ControllerPeriodic() override;
+
+private:
+    static const Eigen::Matrix<double, 2, 2> kGlobalR;
+
+    static const frc::LinearSystem<2, 2, 2> kPlant;
+
+    frc::AnalogInput m_leftUltrasonic{
+        HWConfig::Drivetrain::kLeftUltrasonicChannel};
+    units::meter_t m_leftUltrasonicDistance;
+    frc::AnalogInput m_rightUltrasonic{
+        HWConfig::Drivetrain::kRightUltrasonicChannel};
+    units::meter_t m_rightUltrasonicDistance;
+    frc::LinearFilter<units::meter_t> m_leftDistanceFilter =
+        frc::LinearFilter<units::meter_t>::SinglePoleIIR(0.1, 0.02_s);
+
+    frc::LinearFilter<units::meter_t> m_rightDistanceFilter =
+        frc::LinearFilter<units::meter_t>::SinglePoleIIR(0.1, 0.02_s);
+
+    rev::CANSparkMax m_leftLeader{HWConfig::Drivetrain::kLeftMotorLeaderID,
+                                  rev::CANSparkMax::MotorType::kBrushless};
+    rev::CANSparkMax m_leftFollower{HWConfig::Drivetrain::kLeftMotorFollowerID,
+                                    rev::CANSparkMax::MotorType::kBrushless};
+    frc::MotorControllerGroup m_leftGrbx{m_leftLeader, m_leftFollower};
+
+    rev::CANSparkMax m_rightLeader{HWConfig::Drivetrain::kRightMotorLeaderID,
+                                   rev::CANSparkMax::MotorType::kBrushless};
+    rev::CANSparkMax m_rightFollower{
+        HWConfig::Drivetrain::kRightMotorFollowerID,
+        rev::CANSparkMax::MotorType::kBrushless};
+    frc::MotorControllerGroup m_rightGrbx{m_rightLeader, m_rightFollower};
+
+    frc::Encoder m_leftEncoder{HWConfig::Drivetrain::kLeftEncoderA,
+                               HWConfig::Drivetrain::kLeftEncoderB};
+
+    frc::Encoder m_rightEncoder{HWConfig::Drivetrain::kRightEncoderA,
+                                HWConfig::Drivetrain::kRightEncoderB};
+
+    frc::ADIS16470_IMU m_imu;
+    units::radian_t m_headingOffset = 0_rad;
+
+    frc::UnscentedKalmanFilter<7, 2, 5> m_observer{
+        DrivetrainController::Dynamics,
+        DrivetrainController::LocalMeasurementModel,
+        {0.002, 0.002, 0.0001, 1.5, 1.5, 0.5, 0.5},
+        {0.0001, 0.005, 0.005, 7.0, 7.0},
+        frc::AngleMean<7, 7>(2),
+        frc::AngleMean<5, 7>(0),
+        frc::AngleResidual<7>(2),
+        frc::AngleResidual<5>(0),
+        frc::AngleAdd<7>(2),
+        Constants::kControllerPeriod};
+    frc::KalmanFilterLatencyCompensator<7, 2, 5,
+                                        frc::UnscentedKalmanFilter<7, 2, 5>>
+        m_latencyComp;
+    DrivetrainController m_controller;
+    Eigen::Vector<double, 2> m_u = Eigen::Vector<double, 2>::Zero();
+
+    nt::NetworkTableEntry m_leftUltrasonicOutputEntry =
+        NetworkTableUtil::MakeDoubleEntry(
+            "/Diagnostics/Drivetrain/Outputs/Left Ultrasonic Output");
+
+    nt::NetworkTableEntry m_rightUltrasonicOutputEntry =
+        NetworkTableUtil::MakeDoubleEntry(
+            "/Diagnostics/Drivetrain/Outputs/Right Ultrasonic Output");
+
+    frc::LinearSystem<2, 2, 2> m_imfRef =
+        frc::LinearSystemId::IdentifyDrivetrainSystem(
+            DrivetrainController::kLinearV,
+            DrivetrainController::kLinearA * 5.0,
+            DrivetrainController::kAngularV,
+            DrivetrainController::kAngularA * 2.0);
+    ImplicitModelFollower<2, 2> m_imf{
+        kPlant, m_imfRef, {0.01, 0.01}, {8.0, 8.0}, 20_ms};
+
+    // Simulation variables
+    frc::sim::DifferentialDrivetrainSim m_drivetrainSim{
+        DrivetrainController::GetPlant(), DrivetrainController::kWidth,
+        frc::DCMotor::NEO(2), DrivetrainController::kDriveGearRatio,
+        DrivetrainController::kWheelRadius};
+    frc::sim::EncoderSim m_leftEncoderSim{m_leftEncoder};
+    frc::sim::EncoderSim m_rightEncoderSim{m_rightEncoder};
+    frc::sim::ADIS16470_IMUSim m_imuSim{m_imu};
+    frc::sim::AnalogInputSim m_leftUltrasonicSim{m_leftUltrasonic};
+    frc::sim::AnalogInputSim m_rightUltrasonicSim{m_rightUltrasonic};
+    frc::Field2d m_field;
+
+    /**
+     * Set drivetrain motors to brake mode, which the feedback controllers
+     * expect.
+     */
+    void SetBrakeMode();
+
+    /**
+     * Set drivetrain motors to coast mode so the robot is easier to push when
+     * it's disabled.
+     */
+    void SetCoastMode();
+};
+
+}  // namespace frc3512

--- a/src/test/cpp/DrivetrainTest.cpp
+++ b/src/test/cpp/DrivetrainTest.cpp
@@ -1,0 +1,148 @@
+// Copyright (c) FRC Team 3512. All Rights Reserved.
+
+#include <frc/Notifier.h>
+#include <frc/trajectory/constraint/MaxVelocityConstraint.h>
+#include <frc/trajectory/constraint/RectangularRegionConstraint.h>
+#include <gtest/gtest.h>
+#include <wpi/numbers>
+
+#include "Constants.hpp"
+#include "SimulatorTest.hpp"
+#include "subsystems/Drivetrain.hpp"
+
+class DrivetrainTest : public frc3512::SimulatorTest {
+public:
+    frc3512::Drivetrain drivetrain;
+    frc::Notifier controllerPeriodic{[&] {
+        drivetrain.AutonomousPeriodic();
+        drivetrain.ControllerPeriodic();
+    }};
+
+    DrivetrainTest() {
+        frc3512::SubsystemBase::RunAllAutonomousInit();
+        controllerPeriodic.StartPeriodic(frc3512::Constants::kControllerPeriod);
+    }
+};
+
+TEST_F(DrivetrainTest, ReachesReferenceStraight) {
+    const frc::Pose2d kInitialPose{12.65_m, 5.800_m - 0.343_m,
+                                   units::radian_t{wpi::numbers::pi}};
+
+    drivetrain.Reset(kInitialPose);
+    drivetrain.AddTrajectory(
+        kInitialPose, {},
+        frc::Pose2d(12.65_m - 0.9398_m - 0.5_m, 5.800_m - 0.343_m,
+                    units::radian_t{wpi::numbers::pi}));
+
+    frc::sim::StepTiming(10_s);
+
+    EXPECT_TRUE(drivetrain.AtGoal());
+}
+
+TEST_F(DrivetrainTest, ReachesReferenceCurve) {
+    const frc::Pose2d kInitialPose{0_m, 0_m, 0_rad};
+
+    drivetrain.Reset(kInitialPose);
+    drivetrain.AddTrajectory(kInitialPose, {},
+                             frc::Pose2d(4.8768_m, 2.7432_m, 0_rad));
+
+    frc::sim::StepTiming(10_s);
+
+    EXPECT_TRUE(drivetrain.AtGoal());
+}
+
+TEST_F(DrivetrainTest, ReachesReferenceOffsetCurve) {
+    const frc::Pose2d kInitialPose{5_m, 2_m, 0_rad};
+
+    drivetrain.Reset(kInitialPose);
+    drivetrain.AddTrajectory(kInitialPose, {},
+                             frc::Pose2d(9.8768_m, 4.7432_m, 0_rad));
+
+    frc::sim::StepTiming(10_s);
+
+    EXPECT_TRUE(drivetrain.AtGoal());
+}
+
+TEST_F(DrivetrainTest, TrajectoryQueue) {
+    // Initial Pose - Right in line with the Target Zone
+    const frc::Pose2d kInitialPose{12.89_m, 2.41_m,
+                                   units::radian_t{wpi::numbers::pi}};
+    // Mid Pose - Right before first/closest ball in the Trench Run
+    const frc::Pose2d kMidPose{9.82_m + 0.5 * frc3512::Drivetrain::kLength,
+                               0.705_m, units::radian_t{wpi::numbers::pi}};
+    // End Pose - Third/Farthest ball in the Trench Run
+    const frc::Pose2d kEndPose{8_m, 0.71_m, units::radian_t{wpi::numbers::pi}};
+
+    drivetrain.Reset(kInitialPose);
+
+    frc::RectangularRegionConstraint regionConstraint{
+        // X: Leftmost ball on trench run
+        frc::Translation2d{kEndPose.X(),
+                           0.71_m - 0.5 * frc3512::Drivetrain::kLength},
+        // X: Rightmost ball on trench run
+        frc::Translation2d{9.82_m + 0.5 * frc3512::Drivetrain::kLength,
+                           0.71_m + 0.5 * frc3512::Drivetrain::kLength},
+        frc::MaxVelocityConstraint{1.6_mps}};
+
+    // Add a constraint to slow down the drivetrain while it's
+    // approaching the balls. Interior translation is first/closest ball in
+    // trench run.
+    auto config = frc3512::Drivetrain::MakeTrajectoryConfig();
+    config.AddConstraint(regionConstraint);
+    drivetrain.AddTrajectory({kInitialPose, kMidPose, kEndPose}, config);
+
+    // Drive back
+    auto config2 = frc3512::Drivetrain::MakeTrajectoryConfig();
+    config2.SetReversed(true);
+    drivetrain.AddTrajectory(kEndPose, {}, kMidPose, config2);
+
+    frc::sim::StepTiming(10_s);
+
+    EXPECT_TRUE(drivetrain.AtGoal());
+}
+
+TEST_F(DrivetrainTest, CorrectsTowardGlobalY) {
+    static constexpr bool kIdealModel = false;
+
+    drivetrain.AddTrajectory(frc::Pose2d(0_m, 0_m, 0_rad), {},
+                             frc::Pose2d(4.8768_m, 2.7432_m, 0_rad));
+
+    // Confirm error covariance is nonzero
+    frc::sim::StepTiming(10_s);
+
+    Eigen::Vector<double, 7> x{5.0, 5.0, 1.0, 1.0, 1.0, 1.0, 1.0};
+
+    Eigen::Vector<double, 5> localY =
+        frc3512::DrivetrainController::LocalMeasurementModel(
+            x, Eigen::Vector<double, 2>::Zero());
+    Eigen::Vector<double, 2> globalY =
+        frc3512::DrivetrainController::GlobalMeasurementModel(
+            x, Eigen::Vector<double, 2>::Zero());
+    auto globalTimestamp = frc::Timer::GetFPGATimestamp();
+
+    // Add measurement noise
+    if constexpr (!kIdealModel) {
+        localY += frc::MakeWhiteNoiseVector(0.0001, 0.005, 0.005, 7.0, 7.0);
+        globalY += frc::MakeWhiteNoiseVector(0.05, 0.05);
+    }
+
+    using State = frc3512::DrivetrainController::State;
+    using GlobalOutput = frc3512::DrivetrainController::GlobalOutput;
+
+    auto xHat = drivetrain.GetStates();
+    double xDiff1 = std::abs(xHat(State::kX) - x(State::kX));
+    double yDiff1 = std::abs(xHat(State::kY) - x(State::kY));
+
+    frc::sim::StepTiming(2_s);
+
+    drivetrain.CorrectWithGlobalOutputs(
+        units::meter_t{globalY(GlobalOutput::kX)},
+        units::meter_t{globalY(GlobalOutput::kY)}, globalTimestamp);
+
+    xHat = drivetrain.GetStates();
+    double xDiff2 = std::abs(xHat(State::kX) - x(State::kX));
+    double yDiff2 = std::abs(xHat(State::kY) - x(State::kY));
+
+    EXPECT_GT(xDiff1, xDiff2);
+    EXPECT_GT(yDiff1, yDiff2);
+}


### PR DESCRIPTION
Ports over the 2020 state-space controller for the drivetrain over to the 2022 drivetrain. The reasoning is that both drivetrains are phyiscally similar, so only a few tweaks would have to be made.
