### PR TITLE
Rename kHasNewHeading to m_hasNewHeading

### DIFF
--- a/src/main/cpp/subsystems/Drivetrain.cpp
+++ b/src/main/cpp/subsystems/Drivetrain.cpp
@@ -126,13 +126,13 @@ void Drivetrain::Reset(const frc::Pose2d& initialPose) {
 
     m_observer.Reset();
     m_controller.Reset(initialPose);
-    m_turningPID.Reset(initialPose.Rotation().Radians());
     m_u = Eigen::Vector<double, 2>::Zero();
+    m_turningPID.Reset(initialPose.Rotation().Radians());
+    m_hasNewHeading = false;
     m_leftEncoder.Reset();
     m_rightEncoder.Reset();
     m_imu.Reset();
     m_headingOffset = initialPose.Rotation().Radians();
-    kHasNewHeading = false;
 
     Eigen::Vector<double, 7> xHat;
     xHat(State::kX) = initialPose.X().value();
@@ -198,7 +198,7 @@ void Drivetrain::ControllerPeriodic() {
             m_rightGrbx.Set(m_turningPID.Calculate(units::radian_t{
                 controllerState(DrivetrainController::State::kHeading)}));
         } else {
-            kHasNewHeading = false;
+            m_hasNewHeading = false;
             m_leftGrbx.Set(0.0);
             m_rightGrbx.Set(0.0);
         }
@@ -293,16 +293,16 @@ void Drivetrain::AddTrajectory(const std::vector<frc::Pose2d>& waypoints,
 
 void Drivetrain::SetHeadingGoal(const units::radian_t heading) {
     m_turningPID.SetGoal(frc::AngleModulus(heading));
-    kHasNewHeading = true;
+    m_hasNewHeading = true;
 }
 
-bool Drivetrain::HasHeadingGoal() const { return kHasNewHeading; }
+bool Drivetrain::HasHeadingGoal() const { return m_hasNewHeading; }
 
 void Drivetrain::AbortTurnInPlace() {
     Eigen::Vector<double, 7> controllerState = GetStates();
     m_turningPID.SetGoal(units::radian_t{
         controllerState(DrivetrainController::State::kHeading)});
-    kHasNewHeading = false;
+    m_hasNewHeading = false;
 }
 
 frc::TrajectoryConfig Drivetrain::MakeTrajectoryConfig() {

--- a/src/main/include/subsystems/Drivetrain.hpp
+++ b/src/main/include/subsystems/Drivetrain.hpp
@@ -275,8 +275,6 @@ private:
     static constexpr double kTurningI = 0.0;
     static constexpr double kTurningD = 0.0;
 
-    bool kHasNewHeading = false;
-
     static const Eigen::Matrix<double, 2, 2> kGlobalR;
 
     static const frc::LinearSystem<2, 2, 2> kPlant;
@@ -325,6 +323,7 @@ private:
     frc::ProfiledPIDController<units::radian> m_turningPID{
         kTurningP, kTurningI, kTurningD, m_turningConstraints,
         Constants::kControllerPeriod};
+    bool m_hasNewHeading = false;
 
     frc::LinearSystem<2, 2, 2> m_imfRef =
         frc::LinearSystemId::IdentifyDrivetrainSystem(


### PR DESCRIPTION
k prefixes are reserved for constants, and this variable isn't one. The
declaration was also moved to where its corresponding
ProfiledPIDController is defined, and Reset() calls were reordered to
match the variable declarations.