### PR TITLE
Add external encoder support for both flywheels

### DIFF
--- a/src/main/cpp/FlywheelSim.cpp
+++ b/src/main/cpp/FlywheelSim.cpp
@@ -1,0 +1,52 @@
+// Copyright (c) FRC Team 3512. All Rights Reserved.
+
+#include "FlywheelSim.hpp"
+
+#include <frc/system/plant/LinearSystemId.h>
+#include <wpi/MathExtras.h>
+
+#include "controllers/FlywheelController.hpp"
+
+using namespace frc3512;
+
+FlywheelSim::FlywheelSim(const frc::LinearSystem<1, 1, 1>& plant,
+                         const frc::DCMotor& gearbox, double gearing,
+                         const std::array<double, 2>& measurementStdDevs)
+    : frc::sim::LinearSystemSim<2, 1, 2>(
+          frc::LinearSystem<2, 1, 2>{
+              Eigen::Matrix<double, 2, 2>{{0.0, 1.0}, {0.0, plant.A(0, 0)}},
+              Eigen::Matrix<double, 2, 1>{0.0, plant.B(0, 0)},
+              Eigen::Matrix<double, 2, 2>::Identity(),
+              Eigen::Matrix<double, 2, 1>{0.0, 0.0}},
+          measurementStdDevs),
+      m_gearbox(gearbox),
+      m_gearing(gearing) {}
+
+FlywheelSim::FlywheelSim(const frc::DCMotor& gearbox, double gearing,
+                         units::kilogram_square_meter_t moi,
+                         const std::array<double, 2>& measurementStdDevs)
+    : FlywheelSim(frc::LinearSystemId::FlywheelSystem(gearbox, moi, gearing),
+                  gearbox, gearing, measurementStdDevs) {}
+
+units::radian_t FlywheelSim::GetAngle() const {
+    return units::radian_t{GetOutput(0)};
+}
+
+units::radians_per_second_t FlywheelSim::GetAngularVelocity() const {
+    return units::radians_per_second_t{GetOutput(1)};
+}
+
+units::ampere_t FlywheelSim::GetCurrentDraw() const {
+    using Input = FlywheelController::Input;
+
+    // I = V / R - omega / (Kv * R)
+    // Reductions are greater than 1, so a reduction of 10:1 would mean the
+    // motor is spinning 10x faster than the output.
+    return m_gearbox.Current(GetAngularVelocity() * m_gearing,
+                             units::volt_t{m_u(Input::kVoltage)}) *
+           wpi::sgn(m_u(Input::kVoltage));
+}
+
+void FlywheelSim::SetInputVoltage(units::volt_t voltage) {
+    SetInput(Eigen::Vector<double, 1>{voltage.value()});
+}

--- a/src/main/cpp/Robot.cpp
+++ b/src/main/cpp/Robot.cpp
@@ -173,15 +173,22 @@ void Robot::TeleopPeriodic() {
 
     if (frontFlywheel.IsReady() && backFlywheel.IsReady()) {
         if (driveStick1.GetRawButtonPressed(1) ||
-            driveStick2.GetRawButtonPressed(1)) {
+            driveStick2.GetRawButtonPressed(1) ||
+            driveStick2.GetRawButtonPressed(11)) {
             SetReadyToShoot(true);
         }
     } else {
         if (driveStick1.GetRawButtonPressed(1)) {
-            Shoot(false);
+            Shoot(FrontFlywheelConstants::kShootLow,
+                  BackFlywheelConstants::kShootLow);
         }
         if (driveStick2.GetRawButtonPressed(1)) {
-            Shoot(true);
+            Shoot(FrontFlywheelConstants::kShootHighFender,
+                  BackFlywheelConstants::kShootHighFender);
+        }
+        if (driveStick2.GetRawButtonPressed(11)) {
+            Shoot(FrontFlywheelConstants::kShootHighTarmac,
+                  BackFlywheelConstants::kShootHighTarmac);
         }
     }
 
@@ -224,20 +231,19 @@ void Robot::ExpectAutonomousEndConds() {
         EXPECT_NEAR(
             drivetrain.GetStates()(DrivetrainController::State::kRightVelocity),
             0.0, 0.01);
+
+        EXPECT_EQ(frontFlywheel.GetGoal(), 0_rad_per_s);
+        EXPECT_EQ(backFlywheel.GetGoal(), 0_rad_per_s);
     }
 }
 
 bool Robot::IsShooting() const { return m_state != ShootingState::kIdle; }
 
-void Robot::Shoot(bool shootHigh) {
+void Robot::Shoot(units::radians_per_second_t frontSpeed,
+                  units::radians_per_second_t backSpeed) {
     if (m_state == ShootingState::kIdle) {
-        if (shootHigh) {
-            frontFlywheel.SetGoal(FrontFlywheelConstants::kShootHighFender);
-            backFlywheel.SetGoal(BackFlywheelConstants::kShootHighFender);
-        } else {
-            frontFlywheel.SetGoal(FrontFlywheelConstants::kShootLow);
-            backFlywheel.SetGoal(BackFlywheelConstants::kShootLow);
-        }
+        frontFlywheel.SetGoal(frontSpeed);
+        backFlywheel.SetGoal(backSpeed);
 
         m_shootTimer.Reset();
         m_shootTimer.Start();

--- a/src/main/include/FlywheelSim.hpp
+++ b/src/main/include/FlywheelSim.hpp
@@ -1,0 +1,82 @@
+// Copyright (c) FRC Team 3512. All Rights Reserved.
+
+#pragma once
+
+#include <frc/simulation/LinearSystemSim.h>
+#include <frc/system/LinearSystem.h>
+#include <frc/system/plant/DCMotor.h>
+#include <units/angular_velocity.h>
+#include <units/moment_of_inertia.h>
+
+namespace frc3512 {
+
+/**
+ * Represents a simulated flywheel mechanism with angular position and velocity
+ * states.
+ */
+class FlywheelSim : public frc::sim::LinearSystemSim<2, 1, 2> {
+public:
+    /**
+     * Creates a simulated flywhel mechanism.
+     *
+     * @param plant              The linear system representing the flywheel.
+     * @param gearbox            The type of and number of motors in the
+     *                           flywheel gearbox.
+     * @param gearing            The gearing of the flywheel (numbers greater
+     *                           than 1 represent reductions).
+     * @param measurementStdDevs The standard deviation of the measurement
+     *                           noise.
+     */
+    FlywheelSim(const frc::LinearSystem<1, 1, 1>& plant,
+                const frc::DCMotor& gearbox, double gearing,
+                const std::array<double, 2>& measurementStdDevs = {0.0, 0.0});
+
+    /**
+     * Creates a simulated flywhel mechanism.
+     *
+     * @param gearbox            The type of and number of motors in the
+     * flywheel gearbox.
+     * @param gearing            The gearing of the flywheel (numbers greater
+     * than 1 represent reductions).
+     * @param moi                The moment of inertia of the flywheel.
+     * @param measurementStdDevs The standard deviation of the measurement
+     * noise.
+     */
+    FlywheelSim(const frc::DCMotor& gearbox, double gearing,
+                units::kilogram_square_meter_t moi,
+                const std::array<double, 2>& measurementStdDevs = {0.0, 0.0});
+
+    /**
+     * Returns the flywheel angle.
+     *
+     * @return The flywheel angle.
+     */
+    units::radian_t GetAngle() const;
+
+    /**
+     * Returns the flywheel angular velocity.
+     *
+     * @return The flywheel angular velocity.
+     */
+    units::radians_per_second_t GetAngularVelocity() const;
+
+    /**
+     * Returns the flywheel current draw.
+     *
+     * @return The flywheel current draw.
+     */
+    units::ampere_t GetCurrentDraw() const override;
+
+    /**
+     * Sets the input voltage for the flywheel.
+     *
+     * @param voltage The input voltage.
+     */
+    void SetInputVoltage(units::volt_t voltage);
+
+private:
+    frc::DCMotor m_gearbox;
+    double m_gearing;
+};
+
+}  // namespace frc3512

--- a/src/main/include/HWConfig.hpp
+++ b/src/main/include/HWConfig.hpp
@@ -57,11 +57,17 @@ constexpr int kFrontMotorID = 1;
 /// Back motor CAN ID
 constexpr int kBackMotorID = 2;
 
-/// Encoder channel A
-constexpr int kEncoderA = 6;
+/// Front encoder channel A
+constexpr int kFrontEncoderA = 4;
 
-/// Encoder channel B
-constexpr int kEncoderB = 7;
+/// Front encoder channel B
+constexpr int kFrontEncoderB = 5;
+
+/// Back encoder channel A
+constexpr int kBackEncoderA = 0;
+
+/// Back encoder channel B
+constexpr int kBackEncoderB = 1;
 }  // namespace Flywheel
 
 namespace Intake {

--- a/src/main/include/Robot.hpp
+++ b/src/main/include/Robot.hpp
@@ -169,8 +169,12 @@ public:
     /**
      * Checks whether or not the driver wants to shoot high or low, then changes
      * the state of the state machine to execute shooting sequence.
+     *
+     * @param frontSpeed    Speed for the front flywheel
+     * @param backSpeed     Speed for the back flywheel
      */
-    void Shoot(bool shootHigh);
+    void Shoot(units::radians_per_second_t frontSpeed,
+               units::radians_per_second_t backSpeed);
 
     /**
      * Runs the shooter state machine.

--- a/src/main/include/controllers/FlywheelController.hpp
+++ b/src/main/include/controllers/FlywheelController.hpp
@@ -27,7 +27,7 @@ namespace frc3512 {
 class FlywheelController : public ControllerBase<1, 1, 1> {
 public:
     /// Gear ratio from encoder to both flywheels.
-    static constexpr double kGearRatio = 12.0 / 18.0;
+    static constexpr double kGearRatio = 1.0 / 1.0;
 
     /// Angle per encoder pulse.
     static constexpr double kDpP = (wpi::numbers::pi * 2.0) * kGearRatio / 42;

--- a/src/main/include/subsystems/BackFlywheel.hpp
+++ b/src/main/include/subsystems/BackFlywheel.hpp
@@ -9,12 +9,10 @@
 #include <frc/filter/LinearFilter.h>
 #include <frc/geometry/Pose2d.h>
 #include <frc/simulation/EncoderSim.h>
-#include <frc/simulation/FlywheelSim.h>
 #include <frc/simulation/LinearSystemSim.h>
 #include <frc/system/LinearSystem.h>
 #include <frc/system/plant/LinearSystemId.h>
 #include <rev/CANSparkMax.h>
-#include <rev/SparkMaxRelativeEncoder.h>
 #include <units/angle.h>
 #include <units/angular_velocity.h>
 #include <units/current.h>
@@ -22,6 +20,7 @@
 #include <units/voltage.h>
 
 #include "Constants.hpp"
+#include "FlywheelSim.hpp"
 #include "HWConfig.hpp"
 #include "NetworkTableUtil.hpp"
 #include "controllers/FlywheelController.hpp"
@@ -122,11 +121,21 @@ public:
 
     void ControllerPeriodic() override;
 
+    /**
+     * Sets the simulation model's angular velocity.
+     *
+     * This is useful for simulating balls exiting the shooter.
+     *
+     * @param velocity The simulation's angular velocity.
+     */
+    void SetSimAngularVelocity(units::radians_per_second_t velocity);
+
 private:
     rev::CANSparkMax m_backGrbx{HWConfig::Flywheel::kBackMotorID,
                                 rev::CANSparkMax::MotorType::kBrushless};
 
-    rev::SparkMaxRelativeEncoder m_backEncoder{m_backGrbx.GetEncoder()};
+    frc::Encoder m_backEncoder{HWConfig::Flywheel::kBackEncoderA,
+                               HWConfig::Flywheel::kBackEncoderB};
 
     frc::LinearSystem<1, 1, 1> m_plant{FlywheelController::GetBackPlant()};
     frc::KalmanFilter<1, 1, 1> m_observer{
@@ -155,8 +164,11 @@ private:
     // measuring flywheel lookup table values.
     double m_testThrottle = 0.0;
 
-    nt::NetworkTableEntry m_manualRefEntry = NetworkTableUtil::MakeDoubleEntry(
-        "Diagnostics/Back Flywheel/Manual Ref");
+    // Measurement noise isn't added because the simulated encoder stores the
+    // count as an integer, which already introduces quantization noise.
+    FlywheelSim m_flywheelSim{m_controller.GetBackPlant(), frc::DCMotor::NEO(2),
+                              1.0 / 2.0};
+    frc::sim::EncoderSim m_encoderSim{m_backEncoder};
 
     /**
      * Sets the voltage of the flywheel motor.


### PR DESCRIPTION
Uses external encoders to measure angular velocity rather than the integrated NEO encoders.